### PR TITLE
Add versioninfo test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,7 @@ project(
   LANGUAGES C CXX
 )
 
+enable_testing()
+
 add_subdirectory(src)
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ and then build the project with
 ```
 > cmake --build build
 ```
+
+## Running the tests
+
+Once the build has completed, run the tests by moving into the build
+directory and running the CTest executable that comes with CMake.
+
+```
+> cd build
+> ctest
+```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(versioninfo versioninfo.cpp)
+
+target_link_libraries(versioninfo PRIVATE topotoolbox)
+
+add_test(NAME versioninfo COMMAND versioninfo)

--- a/test/versioninfo.cpp
+++ b/test/versioninfo.cpp
@@ -1,0 +1,11 @@
+extern "C" {
+#include "topotoolbox.h"
+}
+
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  std::cout << "topotoolbox v" << TOPOTOOLBOX_VERSION_MAJOR << "."
+            << TOPOTOOLBOX_VERSION_MINOR << "." << TOPOTOOLBOX_VERSION_PATCH
+            << std::endl;
+}


### PR DESCRIPTION
The versioninfo test executable prints the version number as defined in include/topotoolbox.h. The test ensures that libtopotoolbox can be built and properly linked with a C++ executable.

Tests are run using the CTest framework included with CMake.

Instructions for running the tests are added to the README.