### PR TITLE
Implement sink filling using morphological reconstruction

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -19,6 +19,8 @@
 #define TOPOTOOLBOX_VERSION_MINOR 0
 #define TOPOTOOLBOX_VERSION_PATCH 0
 
+#include <stddef.h>
+
 /*
   has_topotoolbox()
 
@@ -28,4 +30,7 @@
 TOPOTOOLBOX_API
 int has_topotoolbox(void);
 
-#endif
+void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
+
+#endif  // TOPOTOOLBOX_H
+

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -30,7 +30,7 @@
 TOPOTOOLBOX_API
 int has_topotoolbox(void);
 
+TOPOTOOLBOX_API
 void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
 
 #endif  // TOPOTOOLBOX_H
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,7 @@
-add_library(topotoolbox SHARED topotoolbox.c)
+add_library(topotoolbox SHARED
+  topotoolbox.c
+  fillsinks.c
+  morphology/reconstruct.c
+)
 
 target_include_directories(topotoolbox PUBLIC ../include)

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -1,0 +1,47 @@
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "morphology/reconstruct.h"
+#include "topotoolbox.h"
+
+/*
+  Fill sinks in a digital elevation model.
+
+  The arrays pointed to by `output` and `dem` should represent a two
+  dimensional array of size (nrows, ncols). The filled DEM is written
+  to the `output` array.
+
+  `dem` is modified during the processing, but the modifications are
+  reverted before the function returns. Be careful when accessing
+  `dem` concurrently with `fillsinks`.
+
+  Sinks are filled using grayscale morphological reconstruction.
+*/
+void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols) {
+  for (ptrdiff_t col = 0; col < ncols; col++) {
+    for (ptrdiff_t row = 0; row < nrows; row++) {
+      // Invert the DEM
+      dem[col * nrows + row] *= -1.0;
+
+      // Set the boundary pixels of the output equal to the DEM and
+      // the interior pixels equal to -INFINITY.
+      if ((row == 0 || row == (nrows - 1)) &&
+          (col == 0 || col == (ncols - 1))) {
+        output[col * nrows + row] = dem[col * nrows + row];
+      } else {
+        output[col * nrows + row] = -INFINITY;
+      }
+    }
+  }
+
+  reconstruct(output, dem, nrows, ncols);
+
+  // Revert the DEM and the output
+  for (ptrdiff_t col = 0; col < ncols; col++) {
+    for (ptrdiff_t row = 0; row < nrows; row++) {
+      dem[col * nrows + row] *= -1.0;
+      output[col * nrows + row] *= -1.0;
+    }
+  }
+}

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -1,3 +1,5 @@
+#define TOPOTOOLBOX_BUILD
+
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -18,6 +20,7 @@
 
   Sinks are filled using grayscale morphological reconstruction.
 */
+TOPOTOOLBOX_API
 void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols) {
   for (ptrdiff_t col = 0; col < ncols; col++) {
     for (ptrdiff_t row = 0; row < nrows; row++) {

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -56,7 +56,7 @@ ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t nrows,
     // maximum height of the neighborhood and the mask at the current
     // pixel.
 
-    double z = max_height < mask[p] ? max_height : mask[p];
+    float z = max_height < mask[p] ? max_height : mask[p];
 
     if (z != marker[p]) {
       // Increment count only if we change the current pixel
@@ -121,7 +121,7 @@ ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
     // maximum height of the neighborhood and the mask at the current
     // pixel.
 
-    double z = max_height < mask[p] ? max_height : mask[p];
+    float z = max_height < mask[p] ? max_height : mask[p];
     if (z != marker[p]) {
       // Increment count only if we change the current pixel
       count++;

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -1,0 +1,162 @@
+#include "reconstruct.h"
+
+#include <stddef.h>
+
+/*
+  Perform a partial reconstruction by scanning in the forward
+  direction.
+
+  Returns the number of pixels that were modified in the current scan.
+
+  The forward scan replaces every pixel in `marker` with the maximum
+  of a neighborhood consisting of the 4 neighbors already visited by
+  the raster scan, denoted by 'x' in the diagram:
+
+  x x .
+   \|
+  x-o .
+   /
+  x . .
+
+
+  The new marker pixel value is constrained to lie below the
+  corresponding pixel in `mask`.
+ */
+ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t nrows,
+                       ptrdiff_t ncols) {
+  // Offsets for the four neighbors
+  ptrdiff_t col_offset[4] = {-1, -1, -1, 0};
+  ptrdiff_t row_offset[4] = {1, 0, -1, -1};
+
+  ptrdiff_t count = 0;  // Number of modified pixels
+
+  for (ptrdiff_t p = 0; p < nrows * ncols; p++) {
+    ptrdiff_t col = p / nrows;
+    ptrdiff_t row = p % nrows;
+
+    // Compute the maximum of the marker at the current pixel and all
+    // of its previously visisted neighbors
+    float max_height = marker[p];
+    for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
+      ptrdiff_t neighbor_row = row + row_offset[neighbor];
+      ptrdiff_t neighbor_col = col + col_offset[neighbor];
+
+      ptrdiff_t q = neighbor_col * nrows + neighbor_row;
+
+      // Skip pixels outside the boundary
+      if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
+          neighbor_col >= ncols) {
+        continue;
+      }
+
+      max_height = max_height > marker[q] ? max_height : marker[q];
+    }
+
+    // Set the marker at the current pixel to the minimum of the
+    // maximum height of the neighborhood and the mask at the current
+    // pixel.
+
+    double z = max_height < mask[p] ? max_height : mask[p];
+
+    if (z != marker[p]) {
+      // Increment count only if we change the current pixel
+      count++;
+      marker[p] = z;
+    }
+  }
+  return count;
+}
+
+/*
+  Perform a partial reconstruction by scanning in the backward
+  direction.
+
+  Returns the number of pixels that were modified in the current scan.
+
+  The backward scan replaces every pixel in `marker` with the maximum
+  of a neighborhood consisting of the 4 neighbors already visited by
+  the raster scan, denoted by 'x' in the diagram:
+
+  . . x
+     /
+  . o-x
+    |\
+  . x x
+
+
+  The new marker pixel value is constrained to lie below the
+  corresponding pixel in `mask`.
+ */
+ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
+                        ptrdiff_t ncols) {
+  // Offsets for the four neighbors
+  ptrdiff_t col_offset[4] = {1, 1, 1, 0};
+  ptrdiff_t row_offset[4] = {-1, 0, 1, 1};
+
+  ptrdiff_t count = 0;  // Number of modified pixels
+
+  // Note that the loop decreases. p must have a signed type for this
+  // to work correctly.
+  for (ptrdiff_t p = nrows * ncols - 1; p >= 0; p--) {
+    ptrdiff_t col = p / nrows;
+    ptrdiff_t row = p % nrows;
+
+    // Compute the maximum of the marker at the current pixel and all
+    // of its previously visited neighbors
+    float max_height = marker[p];
+    for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
+      ptrdiff_t neighbor_row = row + row_offset[neighbor];
+      ptrdiff_t neighbor_col = col + col_offset[neighbor];
+      ptrdiff_t q = neighbor_col * nrows + neighbor_row;
+
+      // Skip pixels outside the boundary
+      if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
+          neighbor_col >= ncols) {
+        continue;
+      }
+      max_height = max_height > marker[q] ? max_height : marker[q];
+    }
+
+    // Set the marker at the current pixel to the minimum of the
+    // maximum height of the neighborhood and the mask at the current
+    // pixel.
+
+    double z = max_height < mask[p] ? max_height : mask[p];
+    if (z != marker[p]) {
+      // Increment count only if we change the current pixel
+      count++;
+      marker[p] = z;
+    }
+  }
+  return count;
+}
+
+/*
+  Grayscale reconstruction
+
+  Performs a grayscale reconstruction of the `mask` image by the
+  `marker` image using the sequential reconstruction algorithm of Vincent
+  (1993).
+
+  Both `marker` and `mask` should point to two-dimensional arrays of
+  size (nrows, ncols) with the first dimension (nrows) changing
+  fastest. The `marker` array is updated with the result in-place.
+
+  The algorithm alternately scans the marker image in the forward and
+  reverse directions performing a partial reconstruction in each
+  direction. It repeats these scans until no change is detected or
+  until a maximum iteration threshold (currently 1000) is reached.
+
+  Vincent, Luc. (1993). Morphological grayscale reconstruction in
+  image analysis: applications and efficient algorithms. IEEE
+  Transactions on Image Processing, Vol. 2, No. 2.
+  https://doi.org/10.1109/83.217222
+ */
+void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols) {
+  ptrdiff_t n = ncols * nrows;
+  ptrdiff_t iterations = 0;
+  while ((n > 0) && iterations < 1000) {
+    n = forward_scan(marker, mask, nrows, ncols);
+    n += backward_scan(marker, mask, nrows, ncols);
+  }
+}

--- a/src/morphology/reconstruct.h
+++ b/src/morphology/reconstruct.h
@@ -1,0 +1,8 @@
+#ifndef TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H
+#define TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H
+
+#include <stddef.h>
+
+void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols);
+
+#endif  // TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_executable(versioninfo versioninfo.cpp)
-
 target_link_libraries(versioninfo PRIVATE topotoolbox)
-
 add_test(NAME versioninfo COMMAND versioninfo)
-
 set_tests_properties(versioninfo PROPERTIES ENVIRONMENT_MODIFICATION
+"PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
+
+add_executable(fillsinks fillsinks.cpp)
+target_link_libraries(fillsinks PRIVATE topotoolbox)
+add_test(NAME fillsinks COMMAND fillsinks)
+set_tests_properties(fillsinks PROPERTIES ENVIRONMENT_MODIFICATION
 "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")

--- a/test/fillsinks.cpp
+++ b/test/fillsinks.cpp
@@ -14,28 +14,28 @@ extern "C" {
   rendering. Journal of Computer Graphics Techniques. Vol 9,
   No. 3. 21-38.
  */
-double pcg4d(uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
-  uint64_t x = a * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
-  uint64_t y = b * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
-  uint64_t z = c * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
-  uint64_t w = d * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
+float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
+  uint32_t x = a * 1664525u + 1013904223u;
+  uint32_t y = b * 1664525u + 1013904223u;
+  uint32_t z = c * 1664525u + 1013904223u;
+  uint32_t w = d * 1664525u + 1013904223u;
 
   x += y * w;
   y += z * x;
   z += x * y;
   w += y * z;
 
-  x ^= x >> 32;
-  y ^= y >> 32;
-  z ^= z >> 32;
-  w ^= w >> 32;
+  x ^= x >> 16;
+  y ^= y >> 16;
+  z ^= z >> 16;
+  w ^= w >> 16;
 
   x += y * w;
   y += z * x;
   z += x * y;
   w += y * z;
 
-  return (double)(w >> 11) * 0x1.0p-53;
+  return (float)(w >> 8) * 0x1.0p-24;
 }
 
 int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint64_t seed) {
@@ -57,7 +57,7 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint64_t seed) {
   for (ptrdiff_t col = 1; col < ncols - 1; col++) {
     for (ptrdiff_t row = 1; row < nrows - 1; row++) {
       // Each pixel of the filled raster should be >= the DEM
-      double z = output[col * nrows + row];
+      float z = output[col * nrows + row];
 
       if (z < dem[col * nrows + row]) {
         std::cout << "Pixel (" << row << ", " << col << ") is below the DEM"

--- a/test/fillsinks.cpp
+++ b/test/fillsinks.cpp
@@ -1,0 +1,103 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+
+extern "C" {
+#include "topotoolbox.h"
+}
+
+/*
+  PCG4D hash function
+
+
+  Jarzynski, Mark and Olano, Marc. (2020). Hash functions for GPU
+  rendering. Journal of Computer Graphics Techniques. Vol 9,
+  No. 3. 21-38.
+ */
+double pcg4d(uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
+  uint64_t x = a * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
+  uint64_t y = b * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
+  uint64_t z = c * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
+  uint64_t w = d * 0x5851f42d4c957f2d + 0x14057b7ef767814f;
+
+  x += y * w;
+  y += z * x;
+  z += x * y;
+  w += y * z;
+
+  x ^= x >> 32;
+  y ^= y >> 32;
+  z ^= z >> 32;
+  w ^= w >> 32;
+
+  x += y * w;
+  y += z * x;
+  z += x * y;
+  w += y * z;
+
+  return (double)(w >> 11) * 0x1.0p-53;
+}
+
+int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint64_t seed) {
+  // Initialize a random DEM
+  float *dem = new float[nrows * ncols];
+  float *output = new float[nrows * ncols];
+
+  for (ptrdiff_t col = 0; col < ncols; col++) {
+    for (ptrdiff_t row = 0; row < nrows; row++) {
+      dem[col * nrows + row] = 100.0 * pcg4d(row, col, seed, 1);
+    }
+  }
+
+  fillsinks(output, dem, nrows, ncols);
+
+  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
+  ptrdiff_t row_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
+
+  for (ptrdiff_t col = 1; col < ncols - 1; col++) {
+    for (ptrdiff_t row = 1; row < nrows - 1; row++) {
+      // Each pixel of the filled raster should be >= the DEM
+      double z = output[col * nrows + row];
+
+      if (z < dem[col * nrows + row]) {
+        std::cout << "Pixel (" << row << ", " << col << ") is below the DEM"
+                  << std::endl;
+        std::cout << "Value: " << z << std::endl;
+        std::cout << "DEM: " << dem[col * nrows + row] << std::endl;
+        return -1;
+      }
+
+      // No pixel of the filled raster should be surrounded by
+      // neighbors that are higher than it
+      int32_t count = 0;
+      for (ptrdiff_t neighbor = 0; neighbor < 8; neighbor++) {
+        ptrdiff_t neighbor_row = row + row_offset[neighbor];
+        ptrdiff_t neighbor_col = col + col_offset[neighbor];
+
+        if (z < output[neighbor_col * nrows + neighbor_row]) {
+          count++;
+        }
+      }
+
+      if (count == 8) {
+        std::cout << "Pixel (" << row << ", " << col << ") is a sink"
+                  << std::endl;
+        return -1;
+      }
+    }
+  }
+
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  ptrdiff_t nrows = 100;
+  ptrdiff_t ncols = 200;
+
+  for (uint64_t test = 0; test < 100; test++) {
+    int32_t result = random_dem_test(nrows, ncols, test);
+    if (result < 0) {
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
 Resolves #7

# Introduction

TopoToolbox fills sinks in digital elevation models using grayscale morphological reconstruction. This algorithm repeatedly dilates a "marker" image while constraining it to lie below a "mask" image. The negative DEM is used as the mask while the marker is identical to the negative DEM on the boundary pixels but negative infinity in its interior. The morphological reconstruction iteratively fills in the interior of the marker image, but does not descend into sinks of the mask.

# Implementation

src/morphology/reconstruct.c implements the sequential reconstruction algorithm presented by Vincent (1993). The algorithm repeatedly scans in alternating directions through the DEM, updates the marker image based on the values of the marker and mask in a neighborhood around the given pixel and terminates when the marker stops changing. The sequential reconstruction algorithm is not as efficient as a hybrid algorithm presented by Vincent that combines sequential reconstruction with a breadth-first search. However, the hybrid algorithm requires managing a queue of pixels that remain to be updated, while the sequential algorithm requires no memory allocation beyond the marker and mask images.

src/morphology/reconstruct.h exposes the reconstruct function for use elsewhere in topotoolbox. This private header is not, however, exposed to users of the library.

src/fillsinks.c implements `fillsinks` using `reconstruct`. The input and output digital elevation models should be passed in by the caller as pointers to arrays of floats. The input DEM is temporarily modified, but then reverted to its original state before the function returns. This should be safe as long as concurrent accesses to the DEM are avoided, but care should be taken in the future.

include/topotoolbox.h is modified to expose the `fillsinks` function to users of the library.

# Testing

test/fillsinks.cpp tests the `fillsinks` implementation by generating 100 random digital elevation models using a hash function based random number generator and testing two properties of the filled DEM:

1. No pixel should be completely surrounded by pixels of a higher elevation.
2. No pixel should be below the original level of the DEM.

These tests do not completely constrain the sink filling algorithm, however, and should be taken as a starting point for more thorough testing.

# Build

src/CMakeLists.txt is modified to append fillsinks.c and morphology/reconstruct.c to add_library, so that these are compiled into the shared library.

test/CMakeLists.txt is modified to build the `fillsinks` executable and add it to the test runner.