### PR TITLE
Add export definition macros

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1,8 +1,31 @@
 #ifndef TOPOTOOLBOX_H
 #define TOPOTOOLBOX_H
 
+#if defined(TOPOTOOLBOX_BUILD)
+#if defined(_WIN32)
+#define TOPOTOOLBOX_API __declspec(dllexport)
+#else
+#define TOPOTOOLBOX_API
+#endif
+#else
+#if defined(_WIN32)
+#define TOPOTOOLBOX_API __declspec(dllimport)
+#else
+#define TOPOTOOLBOX_API
+#endif
+#endif
+
 #define TOPOTOOLBOX_VERSION_MAJOR 3
 #define TOPOTOOLBOX_VERSION_MINOR 0
 #define TOPOTOOLBOX_VERSION_PATCH 0
+
+/*
+  has_topotoolbox()
+
+  Returns 1. Used to ensure that topotoolbox is compiled and linked
+  correctly.
+ */
+TOPOTOOLBOX_API
+int has_topotoolbox(void);
 
 #endif

--- a/src/topotoolbox.c
+++ b/src/topotoolbox.c
@@ -1,1 +1,5 @@
+#define TOPOTOOLBOX_BUILD
 #include "topotoolbox.h"
+
+TOPOTOOLBOX_API
+int has_topotoolbox() { return 1; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,3 +3,5 @@ add_executable(versioninfo versioninfo.cpp)
 target_link_libraries(versioninfo PRIVATE topotoolbox)
 
 add_test(NAME versioninfo COMMAND versioninfo)
+
+install(FILES $<TARGET_RUNTIME_DLLS:versioninfo> TYPE BIN)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,4 +4,5 @@ target_link_libraries(versioninfo PRIVATE topotoolbox)
 
 add_test(NAME versioninfo COMMAND versioninfo)
 
-install(FILES $<TARGET_RUNTIME_DLLS:versioninfo> TYPE BIN)
+set_tests_properties(versioninfo PROPERTIES ENVIRONMENT_MODIFICATION
+"PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")

--- a/test/versioninfo.cpp
+++ b/test/versioninfo.cpp
@@ -5,7 +5,9 @@ extern "C" {
 #include <iostream>
 
 int main(int argc, char *argv[]) {
-  std::cout << "topotoolbox v" << TOPOTOOLBOX_VERSION_MAJOR << "."
-            << TOPOTOOLBOX_VERSION_MINOR << "." << TOPOTOOLBOX_VERSION_PATCH
-            << std::endl;
+  if (has_topotoolbox()) {
+    std::cout << "topotoolbox v" << TOPOTOOLBOX_VERSION_MAJOR << "."
+              << TOPOTOOLBOX_VERSION_MINOR << "." << TOPOTOOLBOX_VERSION_PATCH
+              << std::endl;
+  }
 }


### PR DESCRIPTION
Windows requires extra attributes to export the symbols from a shared library. Macros similar to the ones defined here are a typical way of handling such attributes.

include/topotoolbox.h adds the TOPOTOOLBOX_API macro, which controls which __declspec attribute is attached to exported API functions. The TOPOTOOLBOX_BUILD flag controls whether the shared library is being built, in which case the symbols must be exported, or used, in which case they must be imported. An API function `has_topotoolbox` is added. This function returns 1 (true), and can be used to test that everything is linked correctly. As more functions are added to the library, this functionality may become less useful.

src/topotoolbox.c defines the TOPOTOOLBOX_BUILD macro and the `has_topotoolbox` function.

test/versioninfo.cpp now uses the `has_topotoolbox` function to check before printing the version number.