### PR TITLE
Add continuous integration with GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - c_compiler: gcc
+            cpp_compiler: g++
+          - c_compiler: clang
+            cpp_compiler: clang++
+          - c_compiler: cl
+            cpp_compiler: cl
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: macos-latest
+            c_compiler: cl
+          - os: macos-latest
+            c_compiler: gcc
+          - os: ubuntu-latest
+            c_compiler: cl
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: >
+          cmake -B ${{github.workspace}}/build
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
+          -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Test
+        run: ctest --test-dir ${{github.workspace}}/build -C ${{env.BUILD_TYPE}}


### PR DESCRIPTION
This creates a workflow that checks out the repository, then builds and tests the repository with our CMake build system. The action is run on Ubuntu with gcc and clang, macos with clang and Windows with MSVC.

.github/workflows/ci.yaml contains the configuration for the CI workflow. It is based loosely on the cmake-multi-platform starter workflow provided by GitHub.