### PR TITLE
Control whether tests are built with the BUILD_TESTING flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,10 @@ project(
   LANGUAGES C CXX
 )
 
-enable_testing()
+include(CTest)
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+if (BUILD_TESTING)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
src/CMakeLists.txt now uses include(CTest) to enable the CTest module and then only adds the build instructions in the test/ directory if BUILD_TESTING is enabled. It is enabled by default. CMake can be configured to build just the library with no tests by running

```
> cmake -B build -DBUILD_TESTING=OFF
```