### PR TITLE
Set C/C++ standards and add more aggressive compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,22 @@ project(
   LANGUAGES C CXX
 )
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
 include(CTest)
+
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+if (MSVC)
+  add_compile_options(/W4 /wd4100)
+else()
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+endif()
 
 add_subdirectory(src)
 

--- a/test/fillsinks.cpp
+++ b/test/fillsinks.cpp
@@ -35,17 +35,17 @@ float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
   z += x * y;
   w += y * z;
 
-  return (float)(w >> 8) * 0x1.0p-24;
+  return (float)(w >> 8) / (1 << 24);
 }
 
-int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint64_t seed) {
+int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
   // Initialize a random DEM
   float *dem = new float[nrows * ncols];
   float *output = new float[nrows * ncols];
 
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
-      dem[col * nrows + row] = 100.0 * pcg4d(row, col, seed, 1);
+  for (uint32_t col = 0; col < ncols; col++) {
+    for (uint32_t row = 0; row < nrows; row++) {
+      dem[col * nrows + row] = 100.0f * pcg4d(row, col, seed, 1);
     }
   }
 
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
   ptrdiff_t nrows = 100;
   ptrdiff_t ncols = 200;
 
-  for (uint64_t test = 0; test < 100; test++) {
+  for (uint32_t test = 0; test < 100; test++) {
     int32_t result = random_dem_test(nrows, ncols, test);
     if (result < 0) {
       return result;


### PR DESCRIPTION
This sets the C++ standard to C++11 and the C standard to C99.

Compiler warnings "/W4" and "-Wall -Wextra -Wpedantic" are used for MSVC and GCC/Clang, respectively. The unused parameter warning is turned off for all compilers now because it warns about argc, argv not being used in main functions.

Compiler warnings are treated as errors using CMake's CMAKE_COMPILE_WARNING_AS_ERROR variable. This can be turned off on the command line with cmake --compile-no-warning-as-error if necessary. For now, it is useful to ensure CI fails when compiler warnings are emitted.

test/fillsinks.cpp is modified to ensure that it builds with the new compiler settings. This requires removing a hexadecimal floating point literal, which is added in C++17 and modifying some of the types of variables passed to the hash function to comply with its interface.