### PR TITLE
Restructure the morphological reconstruction loop

### DIFF
--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -1,6 +1,7 @@
 #include "reconstruct.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 /*
   Perform a partial reconstruction by scanning in the forward
@@ -154,8 +155,9 @@ ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
  */
 void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols) {
   ptrdiff_t n = ncols * nrows;
-  ptrdiff_t iterations = 0;
-  while ((n > 0) && iterations < 1000) {
+
+  const int32_t max_iterations = 1000;
+  for (int32_t iteration = 0; iteration < max_iterations && n > 0; iteration++) {
     n = forward_scan(marker, mask, nrows, ncols);
     n += backward_scan(marker, mask, nrows, ncols);
   }

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -157,7 +157,8 @@ void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols) {
   ptrdiff_t n = ncols * nrows;
 
   const int32_t max_iterations = 1000;
-  for (int32_t iteration = 0; iteration < max_iterations && n > 0; iteration++) {
+  for (int32_t iteration = 0; iteration < max_iterations && n > 0;
+       iteration++) {
     n = forward_scan(marker, mask, nrows, ncols);
     n += backward_scan(marker, mask, nrows, ncols);
   }


### PR DESCRIPTION
This now uses a for loop with an iteration counter up to a maximum number of iterations, which is declared as a named constant. The loop is ended early if the scans stop changing, which indicates convergence. This ensures that the reconstruction will not run forever even in the presence of NaNs or some other reason why it wouldn't converged.

Note that we do not current signal to the caller that the reconstruction has not converged. A value could be returned from this function to indicate whether it has converged, but it is unclear to me what the caller (namely `fillsinks`) should do with that information.