### PR TITLE
Initialize all pixels on the boundary in fillsinks

### DIFF
--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -29,7 +29,7 @@ void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols) {
 
       // Set the boundary pixels of the output equal to the DEM and
       // the interior pixels equal to -INFINITY.
-      if ((row == 0 || row == (nrows - 1)) &&
+      if ((row == 0 || row == (nrows - 1)) ||
           (col == 0 || col == (ncols - 1))) {
         output[col * nrows + row] = dem[col * nrows + row];
       } else {


### PR DESCRIPTION
By using && in this conditional, this only initialized the output/marker with pixels in the corners when we needed to initialize all the boundary pixels. Switching the && to || ensures that all of the boundary pixels are set equal to their value in the inverted DEM before the reconstruction algorithm is run.