### PR TITLE
Add CMake package configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
 include(CTest)
+include(GNUInstallDirs)
 
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 if (MSVC)
@@ -28,3 +29,35 @@ add_subdirectory(src)
 if (BUILD_TESTING)
   add_subdirectory(test)
 endif()
+
+
+# CMake package configuration
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  cmake/TopoToolboxConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfig.cmake
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+# Install library
+install(TARGETS topotoolbox EXPORT topotoolbox-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+install(EXPORT topotoolbox-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ buildsystem in the `build/` directory by running
 > cmake -B build
 ```
 
-and then build the project with
+and then build the library with
 
 ```
+> cmake --build build
+```
+
+By default, CMake builds a static library. To build a shared library,
+call
+
+```
+> cmake -B build -DBUILD_SHARED_LIBS=ON
 > cmake --build build
 ```
 
@@ -26,3 +34,23 @@ directory and running the CTest executable that comes with CMake.
 > cd build
 > ctest
 ```
+
+## Installing the library
+
+If the library is built in the `build/` directory, it can be installed
+using
+
+```
+> cmake --install build
+```
+
+This will attempt to install the library globally, which may require
+administrator privileges. To install to a local path, run
+
+```
+> cmake --install build --prefix /path/to/local/installation
+```
+
+or pass the option
+`-DCMAKE_INSTALL_PREFIX=/path/to/local/installation` to the initial
+`cmake -B build` command.

--- a/cmake/TopoToolboxConfig.cmake.in
+++ b/cmake/TopoToolboxConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/topotoolbox-targets.cmake)
+set_and_check(TopoToolbox_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set(TopoToolbox_LIBRARIES topotoolbox)
+check_required_components(topotoolbox)

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1,7 +1,9 @@
 #ifndef TOPOTOOLBOX_H
 #define TOPOTOOLBOX_H
 
-#if defined(TOPOTOOLBOX_BUILD)
+#ifdef TOPOTOOLBOX_STATICLIB
+#define TOPOTOOLBOX_API
+#elif defined(TOPOTOOLBOX_BUILD)
 #if defined(_WIN32)
 #define TOPOTOOLBOX_API __declspec(dllexport)
 #else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,19 @@
-add_library(topotoolbox SHARED
+add_library(topotoolbox
   topotoolbox.c
   fillsinks.c
   morphology/reconstruct.c
 )
 
-target_include_directories(topotoolbox PUBLIC ../include)
+target_include_directories(
+  topotoolbox
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+
+if (BUILD_SHARED_LIBS)
+else()
+  target_compile_options(topotoolbox PUBLIC -DTOPOTOOLBOX_STATICLIB)
+endif()
+
+set_target_properties(topotoolbox PROPERTIES PUBLIC_HEADER ${CMAKE_SOURCE_DIR}/include/topotoolbox.h)


### PR DESCRIPTION
This sets up a CMake Config package for libtopotoolbox that will allow it to be installed and more easily built by other CMake projects. The end goal is to use the libtopotoolbox CMake package with scikit-build-core to install things properly for pytopotoolbox.

CMakeLists.txt adds a target to install the topotoolbox library and header file in the appropriate lib/ and include/ directories, which are set by GNUInstallDirs. It sets include/topotoolbox.h to be a PUBLIC_HEADER, which allows it to be installed by the install command.

IMPORTANT: A static library is now built by default. The shared library can be built by passing the option -DBUILD_SHARED_LIBS=ON to cmake.

CMakeLists.txt also provides a package configuration that enables CMake's `find_package` to find the library. Something like `find_package(TopoToolbox 3.0.0 REQUIRED)` can add a library called `topotoolbox` to the environment of a CMake build if the CMAKE_PREFIX_PATH is set correctly.

cmake/TopoToolboxConfig.cmake.in is a template for a package configuration.

I have also added the TOPOTOOLBOX_STATICLIB flag to include/topotoolbox.h. This allows us to turn the __declspec definitions off for Windows when we build the static library. We set the flag automatically in src/CMakeLists.txt by checking the value of BUILD_SHARED_LIBS in src/CMakeLists.txt, which controls whether CMake builds a shared or a static library.