### PR TITLE
Fixes to allow dependencies to install libtopotoolbox cleanly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
+          -DTT_BUILD_TESTS=ON
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+OPTION(TT_BUILD_TESTS "Build libtopotoolbox tests" OFF)
+
 include(CTest)
 include(GNUInstallDirs)
 
@@ -26,7 +28,7 @@ endif()
 
 add_subdirectory(src)
 
-if (BUILD_TESTING)
+if (TT_BUILD_TESTS)
   add_subdirectory(test)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,17 @@ call
 > cmake --build build
 ```
 
-## Running the tests
+## Building and running the tests
 
-Once the build has completed, run the tests by moving into the build
-directory and running the CTest executable that comes with CMake.
+libtopotoolbox includes a test suite that can be built alongside the
+library. Turn on the `TT_BUILD_TESTS` option to build the tests as well:
+
+```
+> cmake -B build -DTT_BUILD_TESTS=ON
+> cmake --build build
+```
+
+Tests can then be run with
 
 ```
 > cd build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(topotoolbox
 target_include_directories(
   topotoolbox
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${topotoolbox_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
 )
 
@@ -16,4 +16,4 @@ else()
   target_compile_options(topotoolbox PUBLIC -DTOPOTOOLBOX_STATICLIB)
 endif()
 
-set_target_properties(topotoolbox PROPERTIES PUBLIC_HEADER ${CMAKE_SOURCE_DIR}/include/topotoolbox.h)
+set_target_properties(topotoolbox PROPERTIES PUBLIC_HEADER ${topotoolbox_SOURCE_DIR}/include/topotoolbox.h)


### PR DESCRIPTION
This series of commits updates the CMake project configuration to allow dependencies to install libtopotoolbox successfully with a minimum of extra noise.

src/CMakeLists.txt is updated to point to ${topotoolbox_SOURCE_DIR}/include for the header files, which should allow projects building libtopotoolbox as a dependency to find the headers properly.

CMakeLists.txt now uses a project-specific TT_BUILD_TESTS flag to control whether the internal tests are built. This is off by default, so dependencies will not build the tests alongside the library. The build instructions in the README have been updated, and CI now uses this flag.