### PR TITLE
Identify flat pixels in DEM

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -22,6 +22,7 @@
 #define TOPOTOOLBOX_VERSION_PATCH 0
 
 #include <stddef.h>
+#include <stdint.h>
 
 /*
   has_topotoolbox()
@@ -34,5 +35,9 @@ int has_topotoolbox(void);
 
 TOPOTOOLBOX_API
 void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
+
+TOPOTOOLBOX_API
+void identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
+                   ptrdiff_t ncols);
 
 #endif  // TOPOTOOLBOX_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(topotoolbox
   topotoolbox.c
   fillsinks.c
+  identifyflats.c
   morphology/reconstruct.c
 )
 

--- a/src/identifyflats.c
+++ b/src/identifyflats.c
@@ -1,0 +1,96 @@
+#define TOPOTOOLBOX_BUILD
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "topotoolbox.h"
+
+/*
+  Identify flat regions and sills in a digital elevation model.
+
+  The arrays pointed to by `output` and `dem` should represent
+  two-dimensional arrays of size (nrows, ncols). Pixels that are part
+  of flat regions are labeled with a value of 1 in `output` while the
+  pixels that are sills over which flat regions spill into
+  lower-elevation regions are labeled with a value of 2.
+ */
+TOPOTOOLBOX_API
+void identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
+                   ptrdiff_t ncols) {
+  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
+  ptrdiff_t row_offset[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
+
+  // A flat is a pixel whose elevation is equal to the minimum
+  // elevation of all of its neighbors.
+  for (ptrdiff_t col = 0; col < ncols; col++) {
+    for (ptrdiff_t row = 0; row < nrows; row++) {
+      // Zero the output for all non-flat/sill pixels
+      output[col * nrows + row] = 0;
+
+      // Skip border pixels
+      if (col == 0 || col == ncols - 1 || row == 0 || row == nrows - 1) {
+        continue;
+      }
+
+      float dem_height = dem[col * nrows + row];
+      float min_height = dem_height;
+
+      // Compute the minimum height in the neighborhood around the
+      // current pixel
+      for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
+        ptrdiff_t neighbor_row = row + row_offset[neighbor];
+        ptrdiff_t neighbor_col = col + col_offset[neighbor];
+
+        // neighbor_row and neighbor_col are valid indices because we
+        // skipped border pixels above
+        float neighbor_height = dem[neighbor_col * nrows + neighbor_row];
+        min_height =
+            min_height < neighbor_height ? min_height : neighbor_height;
+      }
+
+      if (dem_height == min_height) {
+        // Pixel is a flat
+        output[col * nrows + row] = 1;
+      }
+    }
+  }
+
+  // A sill is a pixel that
+  // 1. is not a flat
+  // 2. borders at least one flat
+  // 3. has the same elevation as a flat that it touches
+  for (ptrdiff_t col = 0; col < ncols; col++) {
+    for (ptrdiff_t row = 0; row < nrows; row++) {
+      if (output[col * nrows + row] == 1) {
+        // Pixel is a flat, skip it
+        continue;
+      }
+
+      float dem_height = dem[col * nrows + row];
+
+      for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
+        ptrdiff_t neighbor_row = row + row_offset[neighbor];
+        ptrdiff_t neighbor_col = col + col_offset[neighbor];
+
+        if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
+            neighbor_col >= ncols) {
+          // Skip neighbors outside the image
+          continue;
+        }
+
+        if (output[neighbor_col * nrows + neighbor_row] != 1) {
+          // Neighbor is not a flat, skip it
+          continue;
+        }
+
+        float neighbor_height = dem[neighbor_col * nrows + neighbor_row];
+        if (neighbor_height == dem_height) {
+          // flat neighbor has a height equal to that of the current pixel.
+          // Current pixel is a sill
+          output[col * nrows + row] = 2;
+          continue;
+        }
+      }
+    }
+  }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,8 @@ add_test(NAME versioninfo COMMAND versioninfo)
 set_tests_properties(versioninfo PROPERTIES ENVIRONMENT_MODIFICATION
 "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 
-add_executable(fillsinks fillsinks.cpp)
-target_link_libraries(fillsinks PRIVATE topotoolbox)
-add_test(NAME fillsinks COMMAND fillsinks)
-set_tests_properties(fillsinks PROPERTIES ENVIRONMENT_MODIFICATION
+add_executable(random_dem random_dem.cpp)
+target_link_libraries(random_dem PRIVATE topotoolbox)
+add_test(NAME random_dem COMMAND random_dem)
+set_tests_properties(random_dem PROPERTIES ENVIRONMENT_MODIFICATION
 "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")


### PR DESCRIPTION
Resolves #8 

src/identifyflats.c adds the function `identifyflats`, which labels pixels in a DEM whose elevation is equal to the minimum elevation of their neighbors (flats) or whose elevation is equal to that of a neighboring flat (sills).

src/CMakeLists.txt adds src/identifyflats.c the library sources

include/topotoolbox.h adds the prototype for identifyflats

test/fillsinks.cpp is renamed to test/random_dem.cpp because we use random DEMs to test a variety of TopoToolbox functions

test/random_dem.cpp now runs `identifyflats` after `fillsinks` to label flats and sills in the DEM. The following properties are tested:

1. No flat pixel should have a neighbor that is lower than it
2. Every sill pixel should have at least one neighbor lower than it
3. Every sill pixel should border a flat pixel

These tests are incorporated into the loop over neighboring pixels.

test/CMakeLists.txt renames the fillsinks test to the random_dem test.