### PR TITLE
Complete the function prototype for has_topotoolbox

### DIFF
--- a/src/topotoolbox.c
+++ b/src/topotoolbox.c
@@ -2,4 +2,4 @@
 #include "topotoolbox.h"
 
 TOPOTOOLBOX_API
-int has_topotoolbox() { return 1; }
+int has_topotoolbox(void) { return 1; }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -84,9 +84,6 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
       // Number of neighbors that are flats
       int32_t neighboring_flats = 0;
 
-      // Number of neighbors that are sills
-      int32_t neighboring_sills = 0;
-
       // Number of neighboring flats that have the same elevation as
       // the current pixel
       int32_t equal_neighboring_flats = 0;
@@ -119,7 +116,6 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
         }
 
         if (neighboring_flat & 2) {
-          neighboring_sills++;
           if (z == neighbor_height) {
             equal_neighboring_sills++;
           }


### PR DESCRIPTION
has_topotoolbox doesn't require any input parameters. The prototype in include/topotoolbox.h does use has_topotoolbox(void) to indicate this, but the implementation in src/topotoolbox.c does not. This caused CI errors on macos + clang.

src/topotoolbox.c adds a void parameter to the signature of has_topotoolbox