### PR TITLE
Return the number of flats from identifyflats

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -37,7 +37,7 @@ TOPOTOOLBOX_API
 void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
 
 TOPOTOOLBOX_API
-void identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
-                   ptrdiff_t ncols);
+ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
+                        ptrdiff_t ncols);
 
 #endif  // TOPOTOOLBOX_H

--- a/src/identifyflats.c
+++ b/src/identifyflats.c
@@ -29,10 +29,12 @@
   output[p] & 4
  */
 TOPOTOOLBOX_API
-void identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
-                   ptrdiff_t ncols) {
+ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
+                        ptrdiff_t ncols) {
   ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
   ptrdiff_t row_offset[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
+
+  ptrdiff_t count_flats = 0;
 
   // A flat is a pixel whose elevation is equal to the minimum
   // elevation of all of its neighbors.
@@ -65,6 +67,7 @@ void identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
       if (dem_height == min_height) {
         // Pixel is a flat
         output[col * nrows + row] |= 1;
+        count_flats++;
       }
     }
   }
@@ -110,4 +113,5 @@ void identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
       }
     }
   }
+  return count_flats;
 }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -55,7 +55,10 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
   int32_t *flats = new int32_t[nrows * ncols];
 
   fillsinks(filled_dem, dem, nrows, ncols);
-  identifyflats(flats, filled_dem, nrows, ncols);
+  ptrdiff_t count_flats = identifyflats(flats, filled_dem, nrows, ncols);
+
+  // Number of flats identified in the test
+  ptrdiff_t test_count_flats = 0;
 
   // Test properties of filled DEM and identified flats
   ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
@@ -130,6 +133,11 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
         return -1;
       }
 
+      if (up_neighbor_count < 8 && down_neighbor_count == 0) {
+        // This pixel is a flat
+        test_count_flats++;
+      }
+
       // Every pixel with no lower neighbors and fewer than 8
       // up_neighbors should be labeled a flat
       if (up_neighbor_count < 8 && down_neighbor_count == 0 && !(flat & 1)) {
@@ -182,6 +190,13 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
         return -1;
       }
     }
+  }
+
+  if (test_count_flats != count_flats) {
+    std::cout << "Number of flats identified in the test is not equal to the "
+                 "number of flats computed by identifyflats"
+              << std::endl;
+    return -1;
   }
 
   return 0;


### PR DESCRIPTION
Knowing how many flat pixels there are is useful for computing the costs for the gray-weighted distance transform. It is easy enough to compute this in `identifyflats` as flat pixels are identified, and return the number of flats from the function.

include/topotoolbox.h now indicates that `identifyflats` returns a ptrdiff_t.

src/identifyflats.c now increments a counter every time a flat is identified and returns that counter

test/random_dem.cpp is modified to check that the number of identified flats returned from `identifyflats` is equal to those identified while running the test.