### PR TITLE
Compute costs for the gray-weighted distance transform

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -40,4 +40,9 @@ TOPOTOOLBOX_API
 ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
                         ptrdiff_t ncols);
 
+TOPOTOOLBOX_API
+void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
+                   float *original_dem, float *filled_dem, ptrdiff_t nrows,
+                   ptrdiff_t ncols);
+
 #endif  // TOPOTOOLBOX_H

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -41,8 +41,8 @@ ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
                         ptrdiff_t ncols);
 
 TOPOTOOLBOX_API
-void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
-                   float *original_dem, float *filled_dem, ptrdiff_t nrows,
-                   ptrdiff_t ncols);
+void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
+                       float *original_dem, float *filled_dem, ptrdiff_t nrows,
+                       ptrdiff_t ncols);
 
 #endif  // TOPOTOOLBOX_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(topotoolbox
   topotoolbox.c
   fillsinks.c
   identifyflats.c
+  gwdt.c
   morphology/reconstruct.c
 )
 

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -212,8 +212,7 @@ void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
         if (flats[neighbor_pixel] & 1) {
           // Neighbor is a flat, unify it with the current pixel
           // It should have already been inserted, so
-          labeldepth r = unify(conncomps, costs, neighbor_pixel, current_pixel);
-          conncomps[current_pixel] = r.label;
+          unify(conncomps, costs, neighbor_pixel, current_pixel);
         }
       }
     }

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -1,0 +1,241 @@
+#define TOPOTOOLBOX_BUILD
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "topotoolbox.h"
+
+// Gray-weighted distance transforms for auxiliary topography
+
+// This struct lets us return a connected component label and the
+// corresponding depth.
+typedef struct {
+  ptrdiff_t label;
+  float weight;
+} labeldepth;
+
+/*
+  # Cost computation
+
+  To compute the correct costs for the gray-weighted distance
+  transform, the differences between the filled DEM and the original
+  DEM must be subtracted from the maximum depth over each connected
+  component of flat pixels. Computing that maximum depth is done with
+  an algorithm by Wu et al. (2009) and described by He et
+  al. (2017). This algorithm takes two passes over the data. In the
+  first pass, each flat pixel is assigned a provisional label. The
+  labels of neighboring flat pixels are considered /equivalent/
+  because they belong to the same connected component. An /equivalence
+  class/ is a set of equivalent labels. The second pass resolves
+  equivalent labels to a unique label per connected component, with
+  that label determined by the pixel with the highest difference
+  between filled and original DEMs. A third pass over the data
+  computes the costs by subtracting the DEM difference from the
+  maximum depth for the corresponding connected component, squaring
+  the result and adding a small constant to ensure that the costs are
+  nonzero.
+
+  # Union-find implementation
+
+  Equivalence classes of labels are recorded in a union-find data
+  structure. To avoid allocating additional memory for this data
+  structure, it is built into the return values of the `compute_costs`
+  function, namely a ptrdiff_t array of size (nrows,ncols), which
+  holds labels for the connected components, and a float array of the
+  same size, which ultimately holds the costs, but which is used
+  during the algorithm to keep track of the maximum depth over each
+  connected component.
+
+  The union-find data structure works by using the linear index of
+  each pixel as a label of its connected component. A pixel in the
+  labels array therefore points to another pixel in its equivalence
+  class. If it points to itself, it is called the /root/ of that
+  equivalence class. While scanning through the DEM the first time,
+  the algorithm records which equivalence class flat pixels belong to
+  by /unifying/ the labels of neighboring flat pixels, making them
+  point to the same root. The root is selected so that it has the
+  greatest DEM difference of the flat pixels in its equivalence
+  class. The first pass determines the correct equivalence classes of
+  each flat pixel. Every chain of labels eventually leads to a root
+  pixel with the greatest DEM difference in its connected
+  components. However, different pixels in the same connected
+  component may still be labeled with different labels, so a second
+  pass is required to label each pixel with the root of its
+  equivalence class and the corresponding maximum DEM difference.
+
+  # References
+
+  He, L., Ren, X., Gao, Q., Zhao, X., Yao, B., & Chao, Y. (2017). The
+  connected-component labeling problem: A review of state-of-the-art
+  algorithms. Pattern Recognition, 70, 25-43.
+
+  Wu, K., Otoo, E., & Suzuki, K. (2009). Optimizing two-pass
+  connected-component labeling algorithms. Pattern Analysis and
+  Applications, 12, 117-135.
+*/
+
+// Insert pixel into the union-find data structure with a given
+// weight. The pixel is the root of a new disjoint set, so it points
+// to itself in the labels array.
+static void new_tree(ptrdiff_t *labels, float *weights, ptrdiff_t pixel,
+                     float weight) {
+  labels[pixel] = pixel;
+  weights[pixel] = weight;
+}
+
+// To find the root of the disjoint set containing `pixel`, follow the
+// pointers in the `labels` array until reaching a root, where the
+// pointer points to itself. Return the label of the root as well as
+// its corresponding weight.
+static labeldepth find_root(ptrdiff_t *labels, float *weights,
+                            ptrdiff_t pixel) {
+  labeldepth r = {pixel, 0.0};
+  while (labels[r.label] != r.label) {
+    r.label = labels[r.label];
+  }
+  r.weight = weights[r.label];
+  return r;
+}
+
+// The trees in the union-find structure can get very tall, requiring
+// many indirections to find the root of a given pixel. One way of
+// managing the tree height is /path compression/, which traverses the
+// tree starting from `pixel` and sets all of the labels and weights
+// and the weights along the way to `root` and `weight`. The next time
+// any of the pixels on the path is accessed, only one indirection is
+// required to find the root.
+static void set_root(ptrdiff_t *labels, float *weights, ptrdiff_t pixel,
+                     ptrdiff_t root, float weight) {
+  while (labels[pixel] != pixel) {
+    ptrdiff_t v = labels[pixel];
+    labels[pixel] = root;
+    weights[pixel] = weight;
+    pixel = v;
+  }
+  labels[pixel] = root;
+  weights[pixel] = weight;
+}
+
+// The heart of the union-find data structure /unifies/ two pixels by
+// considering them part of the same /equivalence class/. This is done
+// by setting the roots of each pixel to point to the same pixel. The
+// pixel that is chosen to be the new root is that with the greatest
+// weight.
+static labeldepth unify(ptrdiff_t *labels, float *weights, ptrdiff_t pixel1,
+                        ptrdiff_t pixel2) {
+  labeldepth r = find_root(labels, weights, pixel1);
+  if (r.label != pixel2) {
+    labeldepth s = find_root(labels, weights, pixel2);
+    if (r.weight < s.weight) {
+      r = s;
+    }
+    set_root(labels, weights, pixel2, r.label, r.weight);
+  }
+  set_root(labels, weights, pixel1, r.label, r.weight);
+  return r;
+}
+
+/*
+  Cost computation
+
+  `costs`, `original_dem` and `filled_dem` should all represent
+  two-dimensional single-precision floating point arrays of size
+  (nrows, ncols). `flats` represents a two-dimensional 32-bit integer
+  array of the same size that is given by the output of
+  `identifyflats`. `conncomps` represents a two-dimensional ptrdiff_t
+  array of the same size and it is used to store the connected component
+  labels.
+ */
+TOPOTOOLBOX_API
+void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
+                   float *original_dem, float *filled_dem, ptrdiff_t nrows,
+                   ptrdiff_t ncols) {
+  // flats, original_dem and filled_dem are passed as input
+  //
+  // conncomps and costs are outputs
+
+  // Forward scan through the image. Compute local difference between
+  // original and filled_dem. If the current pixel is flat, record its
+  // connected component equivalence class in an implicit union-find
+  // data structure and the maximum difference over its equivalence
+  // class.
+
+  // Four neighbors that have already been visited
+  ptrdiff_t forward_col_offset[4] = {-1, -1, -1, 0};
+  ptrdiff_t forward_row_offset[4] = {-1, 0, 1, -1};
+
+  // All flats are on the interior of the image, so we don't need to
+  // iterate over the borders
+  for (ptrdiff_t col = 0; col < ncols; col++) {
+    for (ptrdiff_t row = 0; row < nrows; row++) {
+      ptrdiff_t current_pixel = col * nrows + row;
+      if (!(flats[current_pixel] & 1)) {
+        // Current pixel is not a flat
+        costs[current_pixel] = 0.0;    // Set cost to zero
+        conncomps[current_pixel] = 0;  // Set connected component label to zero
+        continue;                      // Skip pixel
+      }
+      // Current pixel is a flat
+      float current_depth =
+          filled_dem[current_pixel] - original_dem[current_pixel];
+
+      // Insert the current pixel into the union-find
+      new_tree(conncomps, costs, current_pixel, current_depth);
+
+      for (int32_t neighbor = 0; neighbor < 4; neighbor++) {
+        ptrdiff_t neighbor_col = col + forward_col_offset[neighbor];
+        ptrdiff_t neighbor_row = row + forward_row_offset[neighbor];
+        ptrdiff_t neighbor_pixel = neighbor_col * nrows + neighbor_row;
+
+        if (neighbor_col < 0 || neighbor_col >= ncols || row < 0 ||
+            row >= ncols) {
+          // This should be unreachable, because no border pixel is
+          // also a flat pixel.
+          continue;
+        }
+
+        if (flats[neighbor_pixel] & 1) {
+          // Neighbor is a flat, unify it with the current pixel
+          // It should have already been inserted, so
+          labeldepth r = unify(conncomps, costs, neighbor_pixel, current_pixel);
+          conncomps[current_pixel] = r.label;
+        }
+      }
+    }
+  }
+
+  // Second scan: find the maximum difference for the connected
+  // component of each flat
+  // This time, we don't have to loop over the border pixels
+  for (ptrdiff_t col = 1; col < ncols - 1; col++) {
+    for (ptrdiff_t row = 1; row < nrows - 1; row++) {
+      ptrdiff_t current_pixel = col * nrows + row;
+      if (!(flats[current_pixel] & 1)) {
+        continue;
+      }
+      labeldepth r = find_root(conncomps, costs, current_pixel);
+      conncomps[current_pixel] = r.label;
+      costs[current_pixel] = r.weight;
+    }
+  }
+
+  // Third scan: compute the costs using the max depth for each
+  // connected component
+  for (ptrdiff_t col = 1; col < ncols - 1; col++) {
+    for (ptrdiff_t row = 1; row < nrows - 1; row++) {
+      ptrdiff_t current_pixel = col * nrows + row;
+      if (!(flats[current_pixel] & 1)) {
+        continue;
+      }
+
+      float current_depth =
+          filled_dem[current_pixel] - original_dem[current_pixel];
+
+      // NOTE(wsk): tweight and CarveMinVal hardcoded to 0.1
+      costs[current_pixel] = (costs[current_pixel] - current_depth) *
+                                 (costs[current_pixel] - current_depth) +
+                             0.1f;
+    }
+  }
+}

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -246,10 +246,11 @@ void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
       float current_depth =
           filled_dem[current_pixel] - original_dem[current_pixel];
 
-      // NOTE(wsk): tweight and CarveMinVal hardcoded to 0.1
-      costs[current_pixel] = (costs[current_pixel] - current_depth) *
-                                 (costs[current_pixel] - current_depth) +
-                             0.1f;
+      float tweight = 2.0f;
+      float CarveMinVal = 0.1f;
+
+      costs[current_pixel] =
+          powf(costs[current_pixel] - current_depth, tweight) + CarveMinVal;
     }
   }
 }

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -170,11 +170,12 @@ void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
 
   // Forward scan through the image. Compute local difference between
   // original and filled_dem. If the current pixel is flat, record its
-  // connected component equivalence class in an implicit union-find
-  // data structure and the maximum difference over its equivalence
-  // class.
+  // connected component equivalence class and the maximum elevation
+  // difference over its equivalence class in an implicit union-find
+  // data structure
 
-  // Four neighbors that have already been visited
+  // Offsets to the four neighbors that have already been visited
+  // during the scan
   ptrdiff_t forward_col_offset[4] = {-1, -1, -1, 0};
   ptrdiff_t forward_row_offset[4] = {-1, 0, 1, -1};
 

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -211,7 +211,13 @@ void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
 
         if (flats[neighbor_pixel] & 1) {
           // Neighbor is a flat, unify it with the current pixel
-          // It should have already been inserted, so
+          //
+          // NOTE(wsk): It is possible to unify pixels somewhat more
+          // efficiently by checking whether the neighbors are already
+          // unified. This requires each neighboring pixel to be
+          // checked slightly differently and is more confusing to
+          // read, so it is left for future implementation if
+          // performance improvements are needed.
           unify(conncomps, costs, neighbor_pixel, current_pixel);
         }
       }

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -161,9 +161,9 @@ static labeldepth unify(ptrdiff_t *labels, float *weights, ptrdiff_t pixel1,
   labels.
  */
 TOPOTOOLBOX_API
-void compute_costs(float *costs, ptrdiff_t *conncomps, int32_t *flats,
-                   float *original_dem, float *filled_dem, ptrdiff_t nrows,
-                   ptrdiff_t ncols) {
+void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
+                       float *original_dem, float *filled_dem, ptrdiff_t nrows,
+                       ptrdiff_t ncols) {
   // flats, original_dem and filled_dem are passed as input
   //
   // conncomps and costs are outputs

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -96,7 +96,7 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
           std::cout << "The cost at pixel (" << row << ", " << col
                     << ") is nonpositive" << std::endl;
           return -1;
-        }      
+        }
 
         if (label == 0) {
           std::cout << "Pixel (" << row << ", " << col

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -54,8 +55,14 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
   // Allocate output for identify flats
   int32_t *flats = new int32_t[nrows * ncols];
 
+  // Allocate output for compute_costs
+  ptrdiff_t *conncomps = new ptrdiff_t[nrows * ncols];
+  float *costs = new float[nrows * ncols];
+
+  // Run flow routing algorithms
   fillsinks(filled_dem, dem, nrows, ncols);
   ptrdiff_t count_flats = identifyflats(flats, filled_dem, nrows, ncols);
+  compute_costs(costs, conncomps, flats, dem, filled_dem, nrows, ncols);
 
   // Number of flats identified in the test
   ptrdiff_t test_count_flats = 0;
@@ -68,6 +75,10 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
     for (ptrdiff_t row = 0; row < nrows; row++) {
       float z = filled_dem[col * nrows + row];
       int32_t flat = flats[col * nrows + row];
+      float depth = z - dem[col * nrows + row];
+      float cost = costs[col * nrows + row];
+      ptrdiff_t label = conncomps[col * nrows + row];
+      float maxdepth = sqrtf(cost - 0.1f) + depth;  // Invert the cost equation
 
       int32_t current_pixel_on_border =
           row == 0 || row == nrows - 1 || col == 0 || col == ncols - 1;
@@ -79,6 +90,38 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
         std::cout << "Value: " << z << std::endl;
         std::cout << "DEM: " << dem[col * nrows + row] << std::endl;
         return -1;
+      }
+
+      // Test cost computation
+      if (flat & 1) {
+        if (cost <= 0) {
+          std::cout << "The cost at pixel (" << row << ", " << col
+                    << ") is nonpositive" << std::endl;
+          return -1;
+        }
+
+        if (maxdepth < depth) {
+          std::cout
+              << "The filled - original depth at pixel (" << row << ", " << col
+              << ") is greater than the max depth used in the cost computation"
+              << std::endl;
+          return -1;
+        }
+
+        if (label == 0) {
+          std::cout << "Pixel (" << row << ", " << col
+                    << ") is a flat but has a connected component label of 0"
+                    << std::endl;
+          return -1;
+        }
+      }
+
+      if (!(flat & 1)) {
+        if (cost != 0) {
+          std::cout << "The cost " << cost << " at nonflat pixel (" << row
+                    << ", " << col << ") is nonzero" << std::endl;
+          return -1;
+        }
       }
 
       // Number of neighbors lower than the current pixel
@@ -106,8 +149,11 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
             neighbor_col >= ncols) {
           continue;
         }
+
         float neighbor_height = filled_dem[neighbor_col * nrows + neighbor_row];
         int32_t neighboring_flat = flats[neighbor_col * nrows + neighbor_row];
+        ptrdiff_t neighbor_label =
+            conncomps[neighbor_col * nrows + neighbor_row];
 
         if (z < neighbor_height) {
           up_neighbor_count++;
@@ -122,6 +168,18 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
 
           if (z == neighbor_height) {
             equal_neighboring_flats++;
+          }
+
+          // Flats neighboring other flats should all have the same
+          // connected component label
+          if ((flat & 1) && (neighbor_label != label)) {
+            std::cout << "Pixel (" << row << ", " << col
+                      << ") is a flat bordering another flat with a different "
+                         "connected component label"
+                      << std::endl;
+            std::cout << "Label: " << label << std::endl;
+            std::cout << "Neighbor label: " << neighbor_label << std::endl;
+            return -1;
           }
         }
 

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -75,10 +75,8 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
     for (ptrdiff_t row = 0; row < nrows; row++) {
       float z = filled_dem[col * nrows + row];
       int32_t flat = flats[col * nrows + row];
-      float depth = z - dem[col * nrows + row];
       float cost = costs[col * nrows + row];
       ptrdiff_t label = conncomps[col * nrows + row];
-      float maxdepth = sqrtf(cost - 0.1f) + depth;  // Invert the cost equation
 
       int32_t current_pixel_on_border =
           row == 0 || row == nrows - 1 || col == 0 || col == ncols - 1;
@@ -98,15 +96,7 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
           std::cout << "The cost at pixel (" << row << ", " << col
                     << ") is nonpositive" << std::endl;
           return -1;
-        }
-
-        if (maxdepth < depth) {
-          std::cout
-              << "The filled - original depth at pixel (" << row << ", " << col
-              << ") is greater than the max depth used in the cost computation"
-              << std::endl;
-          return -1;
-        }
+        }      
 
         if (label == 0) {
           std::cout << "Pixel (" << row << ", " << col

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -62,7 +62,7 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
   // Run flow routing algorithms
   fillsinks(filled_dem, dem, nrows, ncols);
   ptrdiff_t count_flats = identifyflats(flats, filled_dem, nrows, ncols);
-  compute_costs(costs, conncomps, flats, dem, filled_dem, nrows, ncols);
+  gwdt_computecosts(costs, conncomps, flats, dem, filled_dem, nrows, ncols);
 
   // Number of flats identified in the test
   ptrdiff_t test_count_flats = 0;


### PR DESCRIPTION
This PR resolves #9, computing the costs for the gray-weighted distance transform.

The main challenge here is in identifying the connected components of flat pixels, which in MATLAB is done with `bwconncomp`. I've implemented a connected components labeling algorithm, which closely follows the OCL algorithm discussed in [this paper](https://doi.org/10.1016/j.patcog.2017.04.018). 

The one modification that I've made is to store the union-find data structure that maintains provisional component labels in the output arrays. This avoids dynamically allocating memory for the union-find data structure, but I am worried that it might be confusing and hard to maintain going forward. 

@Teschl if you have some time, would you mind looking over this PR to see if you can understand what it is doing? Any questions you have now might be questions that maintainers will have later, so I'd like to make sure we document any unclear parts of this code while I still remember what I've written.