### PR TITLE
Remove sphinx-doxygen branch from docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: ["main","sphinx-doxygen"]
+    branches: ["main"]
 
 jobs:
   build:


### PR DESCRIPTION
This was previously used for testing in a separate branch that only existed in my fork, it is no longer necessary for the main repository.