### PR TITLE
Add explicit link to topotoolbox.github.io

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,7 @@ libtopotoolbox in higher-level languages such as Python
 ([topotoolbox](https://github/TopoToolbox/topotoolbox)). If you are
 interested mainly in using TopoToolbox for your work, studies or
 research, you might find the documentation at
-https://topotoolbox.github.io more useful.
+<https://topotoolbox.github.io> more useful.
 
 We use git as a version control system and GitHub's Issues and Pull
 Requests to manage contributions to libtopotoolbox. If you need some


### PR DESCRIPTION
GitHub's Markdown renderer displays a raw URL as an HTML link, but myst-parser does not, so this link did not show up in our online documentation. The angle brackets should make it display properly in both circumstances.