### PR TITLE
Use pip to install Python dependencies in docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,10 @@ jobs:
       - name: Install doxygen
         run: |
           sudo apt update
-          sudo apt install doxygen python3-sphinx python3-breathe python3-myst-parser python3-sphinx-book-theme
+          sudo apt install doxygen
+      - name: Install Python build dependencies
+        run: |
+          pip install sphinx breathe myst-parser sphinx-book-theme          
       - name: Configure
         run: >
           cmake -B ${{github.workspace}}/build -DTT_BUILD_DOCS=ON


### PR DESCRIPTION
This partially addresses #42.