### PR TITLE
Add docs/requirements.txt to install docs' Python build deps

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt install doxygen
       - name: Install Python build dependencies
         run: |
-          pip install sphinx breathe myst-parser sphinx-book-theme          
+          pip install -r ${{github.workspace}}/docs/requirements.txt
       - name: Configure
         run: >
           cmake -B ${{github.workspace}}/build -DTT_BUILD_DOCS=ON

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+breathe==4.35.0
+myst-parser==3.0.1
+Sphinx==7.3.7
+sphinx-book-theme==1.1.2


### PR DESCRIPTION
Closes #42 

docs/requirements.txt fixes versions for the dependencies required to build the docs with Sphinx. This is then used in the docs workflow to install those dependencies before building.