### PR TITLE
Define TOPOTOOLBOX_BUILD in excesstopography.c

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         c_compiler: [gcc, clang, cl]
+        build_shared: [true, false]
         include:
           - c_compiler: gcc
             cpp_compiler: g++
@@ -53,6 +54,7 @@ jobs:
           -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
+          -DBUILD_SHARED_LIBS=${{matrix.build_shared}}
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
       - name: Test

--- a/src/excesstopography.c
+++ b/src/excesstopography.c
@@ -1,3 +1,5 @@
+#define TOPOTOOLBOX_BUILD
+
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
We must remember to do this for every file that implements TOPOTOOLBOX_API functions, because it controls whether the Windows __declspec is dllexport or dllimport. This only affects Windows, so it did not show up on our Unix development machines, and we didn't catch this in our CI because we only ever build static libraries.

.github/workflows/ci.yaml adds a shared library build step to catch errors like this.