### PR TITLE
Implement automatic weekly releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ jobs:
   release:
     name: Tag and create a new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Generate tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,12 @@ jobs:
       - name: Generate tag
         run: echo "TAG=$(date -u +%Y-W%W)" >> $GITHUB_ENV
       - run: 'echo "TAG: $TAG"'
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create $TAG --generate-notes -p
+          
           
   
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,18 @@
+name: Create release
+
+on:
+  push:
+    branches: ["release-test"]
+
+jobs:
+  release:
+    name: Tag and create a new release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate tag
+        run: echo "TAG=$(date -u +%Y-W%W)" >> $GITHUB_ENV
+      - run: 'echo "TAG: $TAG"'
+          
+  
+
+  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create $TAG --generate-notes --latest
+          gh release create $TAG --generate-notes --latest -n "This \
+          is an automatically generated weekly release of the \
+          libtopotoolbox source code. Weekly releases have been \
+          tested, but they should be considered unstable. Check the \
+          release notes associated with each release before \
+          upgrading."
           
           
   

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create $TAG --generate-notes -p
+          gh release create $TAG --generate-notes -p --latest
           
           
   

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create $TAG --generate-notes -p --latest
+          gh release create $TAG --generate-notes --latest
           
           
   

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
     name: Tag and create a new release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Generate tag
         run: echo "TAG=$(date -u +%Y-W%W)" >> $GITHUB_ENV
       - run: 'echo "TAG: $TAG"'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Create release
+name: Weekly release
 
 on:
   schedule:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Create release
 
 on:
-  push:
-    branches: ["release-test"]
+  schedule:
+    - cron: '35 9 * * 2'
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Create release
 
 on:
   schedule:
-    - cron: '35 9 * * 2'
+    - cron: '35 6 * * 1'
 
 jobs:
   release:


### PR DESCRIPTION
This PR implements a GitHub Actions workflow that automatically tags and releases a source code archive every Monday.

We are starting to get to the point where we need better control over which version of libtopotoolbox we are using in downstream projects. There are some outstanding issues (namely #23) that I have held off on because they will break pytopotoolbox, and we don't have a good way of cleanly managing that transition.

These releases are not meant to be "official" libtopotoolbox releases. They exist only to allow downstream projects to pin the version of libtopotoolbox they are currently using. The version numbering explicitly does not follow semantic versioning, and each weekly release should be considered potentially breaking. A disclaimer to that effect is included in the release notes.

The tags have the format `2024-W26` using the year and the ISO week number. Thus pytopotoolbox can say, in its `CMakeLists.txt` file:

```
FetchContent_Declare(
  topotoolbox
  GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
  GIT_TAG 2024-W26
)
```

to ensure that it always grabs the week 26 version of libtopotoolbox once that version has been released.

Once things stabilize a bit more across the TopoToolbox ecosystem, we might consider changing the release cycle and version numbering scheme.

@Teschl: does this make sense? Once we make the first release for libtopotoolbox, we should pin the version number in pytopotoolbox's `CMakeLists.txt`. A release won't be automatically created until next Monday, but I will manually create one once I merge this PR.
