### PR TITLE
excesstopography: Fix numerical error in eikonal solver

### DIFF
--- a/src/excesstopography.c
+++ b/src/excesstopography.c
@@ -34,8 +34,7 @@ static float eikonal_solver(float *solution, float fi, ptrdiff_t i, ptrdiff_t j,
   // Solve the discretized eikonal equation for the central pixel
   // using its two upwind derivatives.
   if (fabsf(u1 - u2) < fi) {
-    return (u1 + u2) / 2 +
-           sqrtf((u1 + u2) * (u1 + u2) - 2 * (u1 * u1 + u2 * u2 - fi * fi)) / 2;
+    return (u1 + u2) / 2 + sqrtf(-(u1 - u2) * (u1 - u2) + 2 * (fi * fi)) / 2;
   } else {
     return fminf(u1 + fi, u2 + fi);
   }


### PR DESCRIPTION
Fixes #53

This bug turns out to result from numerical issues when applying the eikonal solver, especially when the elevations are large and the slopes are small. You end up taking the square root of a negative number and the resulting proposal is NaN, which is never accepted and so the infinite elevations are left in the DEM. Modifying the eikonal solution formula seems to avoid these numerical problems even while still using single precision data.

A new test is added to test/excesstopography.cpp to verify this behavior. It does not directly test the eikonal solver, but instead tests the case from #53.