### PR TITLE
Move pcg4d to test/utils.c

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,22 @@
-add_executable(versioninfo versioninfo.cpp)
+add_executable(versioninfo versioninfo.cpp utils.c)
 target_link_libraries(versioninfo PRIVATE topotoolbox)
 add_test(NAME versioninfo COMMAND versioninfo)
 set_tests_properties(versioninfo PROPERTIES ENVIRONMENT_MODIFICATION
 "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 
-add_executable(random_dem random_dem.cpp)
+add_executable(random_dem random_dem.cpp utils.c)
 target_link_libraries(random_dem PRIVATE topotoolbox)
 add_test(NAME random_dem COMMAND random_dem)
 set_tests_properties(random_dem PROPERTIES ENVIRONMENT_MODIFICATION
   "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 
-add_executable(excesstopography excesstopography.cpp)
+add_executable(excesstopography excesstopography.cpp utils.c)
 target_link_libraries(excesstopography PRIVATE topotoolbox)
 add_test(NAME excesstopography COMMAND excesstopography)
 set_tests_properties(excesstopography PROPERTIES ENVIRONMENT_MODIFICATION
   "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 
-add_executable(gwdt gwdt.cpp)
+add_executable(gwdt gwdt.cpp utils.c)
 target_link_libraries(gwdt PRIVATE topotoolbox)
 add_test(NAME gwdt COMMAND gwdt)
 set_tests_properties(gwdt PROPERTIES ENVIRONMENT_MODIFICATION

--- a/test/excesstopography.cpp
+++ b/test/excesstopography.cpp
@@ -5,30 +5,7 @@
 
 extern "C" {
 #include "topotoolbox.h"
-}
-
-static float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
-  uint32_t x = a * 1664525u + 1013904223u;
-  uint32_t y = b * 1664525u + 1013904223u;
-  uint32_t z = c * 1664525u + 1013904223u;
-  uint32_t w = d * 1664525u + 1013904223u;
-
-  x += y * w;
-  y += z * x;
-  z += x * y;
-  w += y * z;
-
-  x ^= x >> 16;
-  y ^= y >> 16;
-  z ^= z >> 16;
-  w ^= w >> 16;
-
-  x += y * w;
-  y += z * x;
-  z += x * y;
-  w += y * z;
-
-  return (float)(w >> 8) / (1 << 24);
+#include "utils.h"
 }
 
 float upwind_gradient(float *u, ptrdiff_t row, ptrdiff_t col, float cellsize,

--- a/test/gwdt.cpp
+++ b/test/gwdt.cpp
@@ -5,33 +5,10 @@
 
 extern "C" {
 #include "topotoolbox.h"
+#include "utils.h"
 }
 
 #define SQRT2f 1.41421356237309504880f
-
-static float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
-  uint32_t x = a * 1664525u + 1013904223u;
-  uint32_t y = b * 1664525u + 1013904223u;
-  uint32_t z = c * 1664525u + 1013904223u;
-  uint32_t w = d * 1664525u + 1013904223u;
-
-  x += y * w;
-  y += z * x;
-  z += x * y;
-  w += y * z;
-
-  x ^= x >> 16;
-  y ^= y >> 16;
-  z ^= z >> 16;
-  w ^= w >> 16;
-
-  x += y * w;
-  y += z * x;
-  z += x * y;
-  w += y * z;
-
-  return (float)(w >> 8) / (1 << 24);
-}
 
 int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
   float *dem = new float[nrows * ncols];

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -5,38 +5,7 @@
 
 extern "C" {
 #include "topotoolbox.h"
-}
-
-/*
-  PCG4D hash function
-
-
-  Jarzynski, Mark and Olano, Marc. (2020). Hash functions for GPU
-  rendering. Journal of Computer Graphics Techniques. Vol 9,
-  No. 3. 21-38.
- */
-float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
-  uint32_t x = a * 1664525u + 1013904223u;
-  uint32_t y = b * 1664525u + 1013904223u;
-  uint32_t z = c * 1664525u + 1013904223u;
-  uint32_t w = d * 1664525u + 1013904223u;
-
-  x += y * w;
-  y += z * x;
-  z += x * y;
-  w += y * z;
-
-  x ^= x >> 16;
-  y ^= y >> 16;
-  z ^= z >> 16;
-  w ^= w >> 16;
-
-  x += y * w;
-  y += z * x;
-  z += x * y;
-  w += y * z;
-
-  return (float)(w >> 8) / (1 << 24);
+#include "utils.h"
 }
 
 int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,0 +1,28 @@
+#include "utils.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
+  uint32_t x = a * 1664525u + 1013904223u;
+  uint32_t y = b * 1664525u + 1013904223u;
+  uint32_t z = c * 1664525u + 1013904223u;
+  uint32_t w = d * 1664525u + 1013904223u;
+
+  x += y * w;
+  y += z * x;
+  z += x * y;
+  w += y * z;
+
+  x ^= x >> 16;
+  y ^= y >> 16;
+  z ^= z >> 16;
+  w ^= w >> 16;
+
+  x += y * w;
+  y += z * x;
+  z += x * y;
+  w += y * z;
+
+  return (float)(w >> 8) / (1 << 24);
+}

--- a/test/utils.h
+++ b/test/utils.h
@@ -1,0 +1,12 @@
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+  PCG4D hash function
+
+
+  Jarzynski, Mark and Olano, Marc. (2020). Hash functions for GPU
+  rendering. Journal of Computer Graphics Techniques. Vol 9,
+  No. 3. 21-38.
+ */
+float pcg4d(uint32_t a, uint32_t b, uint32_t c, uint32_t d);


### PR DESCRIPTION
Closes #56 

This commit introduces an internal module test/utils.c where we can put test-specific utilities to prevent duplication. The pcg4d random number generator that we use in the three test executables has been moved into this module.

This may not be the final location for these things. I'm not a huge fan of a catch-all `utils` file, but it works for now.