### PR TITLE
Remove the -g flag from compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 if (MSVC)
   add_compile_options(/W4 /wd4100)
 else()
-  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter -g)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
 add_subdirectory(src)


### PR DESCRIPTION
I added the -g to generate debug information because I had thought that it was not getting generated properly when
CMAKE_BUILD_TYPE=Debug. This was actually because the default CMAKE_BUILD_TYPE is not Debug but a toolchain-specific value. If I explicitly build with CMAKE_BUILD_TYPE=Debug, -g is set and we get debug information.