### PR TITLE
Run static and shared library paths within the same job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         c_compiler: [gcc, clang, cl]
-        build_shared: [true, false]
         build_type: [Debug, Release]
         include:
           - c_compiler: gcc
@@ -48,18 +47,31 @@ jobs:
             c_compiler: cl
     steps:
       - uses: actions/checkout@v4
-      - name: Configure
+      - name: Configure static library
         env:
           SANITIZE: ${{ matrix.build_type == 'Debug' && matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'clang' && 'ON' || 'OFF' }}
         run: >
-          cmake -B ${{github.workspace}}/build
+          cmake -B ${{github.workspace}}/build/static
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
-          -DBUILD_SHARED_LIBS=${{matrix.build_shared}}
+          -DBUILD_SHARED_LIBS=OFF
           -DTT_SANITIZE=${{env.SANITIZE}}
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
-      - name: Test
-        run: ctest --test-dir ${{github.workspace}}/build -C ${{matrix.build_type}} --output-on-failure
+      - name: Build static library
+        run: cmake --build ${{github.workspace}}/build/static --config ${{matrix.build_type}}
+      - name: Test static library
+        run: ctest --test-dir ${{github.workspace}}/build/static -C ${{matrix.build_type}} --output-on-failure
+      - name: Configure shared library
+        if: ${{ matrix.build_type == 'Release' }}
+        run: >
+          cmake -B ${{github.workspace}}/build/shared
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
+          -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
+          -DTT_BUILD_TESTS=ON
+          -DBUILD_SHARED_LIBS=ON
+          -DTT_SANITIZE=OFF
+      - name: Build shared library
+        if: ${{ matrix.build_type == 'Release' }}
+        run: cmake --build ${{github.workspace}}/build/shared --config ${{matrix.build_type}}


### PR DESCRIPTION
Partially addresses #61 

This cuts down on the number of CI jobs we run by first building the static library then building and running the tests with the static library, then building the shared library and dynamically linking the tests. We don't run the tests again in the interest of time. The shared library build was introduced in #48 to detect problems with the export definitions that only show up at link time in shared libraries on Windows. If the library and the tests build and link properly, then this issue should be caught.