### PR TITLE
Run only one Debug job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,6 @@ on:
   push:
     branches: ["main"]
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   format-check:
     name: Format check
@@ -19,14 +16,30 @@ jobs:
         uses: jidicula/clang-format-action@v4.11.0
         with:
           clang-format-version: '14'
-  build:
+  debug-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: >
+          cmake -B ${{github.workspace}}/build/debug
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DTT_BUILD_TESTS=ON
+          -DBUILD_SHARED_LIBS=OFF
+          -DTT_SANITIZE=ON
+      - name: Build library
+        run: cmake --build ${{github.workspace}}/build/debug --config Debug
+      - name: Test
+        run: ctest --test-dir ${{github.workspace}}/build/debug -C Debug --output-on-failure
+  release-build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         c_compiler: [gcc, clang, cl]
-        build_type: [Debug, Release]
         include:
           - c_compiler: gcc
             cpp_compiler: g++
@@ -48,30 +61,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure static library
-        env:
-          SANITIZE: ${{ matrix.build_type == 'Debug' && matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'clang' && 'ON' || 'OFF' }}
         run: >
           cmake -B ${{github.workspace}}/build/static
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
           -DBUILD_SHARED_LIBS=OFF
-          -DTT_SANITIZE=${{env.SANITIZE}}
       - name: Build static library
-        run: cmake --build ${{github.workspace}}/build/static --config ${{matrix.build_type}}
+        run: cmake --build ${{github.workspace}}/build/static --config Release
       - name: Test static library
-        run: ctest --test-dir ${{github.workspace}}/build/static -C ${{matrix.build_type}} --output-on-failure
+        run: ctest --test-dir ${{github.workspace}}/build/static -C Release --output-on-failure
       - name: Configure shared library
-        if: ${{ matrix.build_type == 'Release' }}
         run: >
           cmake -B ${{github.workspace}}/build/shared
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
           -DBUILD_SHARED_LIBS=ON
           -DTT_SANITIZE=OFF
       - name: Build shared library
-        if: ${{ matrix.build_type == 'Release' }}
-        run: cmake --build ${{github.workspace}}/build/shared --config ${{matrix.build_type}}
+        run: cmake --build ${{github.workspace}}/build/shared --config Release


### PR DESCRIPTION
Fixes #61

A new job is added to .github/workflows/ci.yaml that builds the Debug configuration and runs the tests with AddressSanitizer on Ubuntu. The other jobs build the Release configuration and run the tests on various operating systems. The Release jobs also continue to build the shared library to confirm that it links properly.