### PR TITLE
Implement strided array access for fillsinks

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -48,7 +48,7 @@ int has_topotoolbox(void);
    @param[in]  ncols  The size of both DEMs in the slowest changing dimension
  */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
 
 /**
    @brief Labels flat, sill and presill pixels in the provided DEM

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -48,7 +48,8 @@ int has_topotoolbox(void);
    @param[in]  ncols  The size of both DEMs in the slowest changing dimension
  */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2],
+               ptrdiff_t strides[2]);
 
 /**
    @brief Labels flat, sill and presill pixels in the provided DEM

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -42,10 +42,14 @@ int has_topotoolbox(void);
 
    Uses an algorithm based on grayscale morphological reconstruction.
 
-   @param[out] output The filled DEM
-   @param[in]  dem    The input DEM
-   @param[in]  nrows  The size of both DEMs in the fastest changing dimension
-   @param[in]  ncols  The size of both DEMs in the slowest changing dimension
+   @param[out] output  The filled DEM
+   @param[in]  dem     The input DEM
+   @param[in]  dims    The size of both DEMs. The first element should be the
+                       dimension whose index changes most quickly as one steps
+                       through the array, and the second element should be the
+                       dimension whose index changes most slowly
+   @param[in]  strides The distance between adjacent elements in the first and
+                       second dimensions
  */
 TOPOTOOLBOX_API
 void fillsinks(float *output, float *dem, ptrdiff_t dims[2],

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -21,32 +21,30 @@
   Sinks are filled using grayscale morphological reconstruction.
 */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t dims[2], ptrdiff_t strides[2]) {
-  ptrdiff_t nrows = dims[0];
-  ptrdiff_t ncols = dims[1];
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2], ptrdiff_t strides[2]) { 
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
       // Invert the DEM
-      dem[col * nrows + row] *= -1.0;
+      dem[i * strides[0] + j * strides[1]] *= -1.0;
 
       // Set the boundary pixels of the output equal to the DEM and
       // the interior pixels equal to -INFINITY.
-      if ((row == 0 || row == (nrows - 1)) ||
-          (col == 0 || col == (ncols - 1))) {
-        output[col * nrows + row] = dem[col * nrows + row];
+      if ((i == 0 || i == (dims[0] - 1)) ||
+          (j == 0 || j == (dims[1] - 1))) {
+        output[i * strides[0] + j * strides[1]] = dem[i * strides[0] + j * strides[1]];
       } else {
-        output[col * nrows + row] = -INFINITY;
+        output[i * strides[0] + j * strides[1]] = -INFINITY;
       }
     }
   }
 
-  reconstruct(output, dem, nrows, ncols);
+  reconstruct(output, dem, dims, strides);
 
   // Revert the DEM and the output
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
-      dem[col * nrows + row] *= -1.0;
-      output[col * nrows + row] *= -1.0;
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      dem[i * strides[0] + j * strides[1]] *= -1.0;
+      output[i * strides[0] + j * strides[1]] *= -1.0;
     }
   }
 }

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -21,7 +21,9 @@
   Sinks are filled using grayscale morphological reconstruction.
 */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols) {
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2], ptrdiff_t strides[2]) {
+  ptrdiff_t nrows = dims[0];
+  ptrdiff_t ncols = dims[1];
   for (ptrdiff_t col = 0; col < ncols; col++) {
     for (ptrdiff_t row = 0; row < nrows; row++) {
       // Invert the DEM

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -11,8 +11,10 @@
   Fill sinks in a digital elevation model.
 
   The arrays pointed to by `output` and `dem` should represent a two
-  dimensional array of size (nrows, ncols). The filled DEM is written
-  to the `output` array.
+  dimensional array of size `dims` with the first dimension changing
+  the fastest in the array. The distance between adjacent elements in
+  the first and second dimensions is given by the respective elements
+  of `strides`. The filled DEM is written to the `output` array.
 
   `dem` is modified during the processing, but the modifications are
   reverted before the function returns. Be careful when accessing
@@ -21,7 +23,8 @@
   Sinks are filled using grayscale morphological reconstruction.
 */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t dims[2], ptrdiff_t strides[2]) { 
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2],
+               ptrdiff_t strides[2]) {
   for (ptrdiff_t j = 0; j < dims[1]; j++) {
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
       // Invert the DEM
@@ -29,9 +32,9 @@ void fillsinks(float *output, float *dem, ptrdiff_t dims[2], ptrdiff_t strides[2
 
       // Set the boundary pixels of the output equal to the DEM and
       // the interior pixels equal to -INFINITY.
-      if ((i == 0 || i == (dims[0] - 1)) ||
-          (j == 0 || j == (dims[1] - 1))) {
-        output[i * strides[0] + j * strides[1]] = dem[i * strides[0] + j * strides[1]];
+      if ((i == 0 || i == (dims[0] - 1)) || (j == 0 || j == (dims[1] - 1))) {
+        output[i * strides[0] + j * strides[1]] =
+            dem[i * strides[0] + j * strides[1]];
       } else {
         output[i * strides[0] + j * strides[1]] = -INFINITY;
       }

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -142,8 +142,10 @@ ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t dims[2],
   (1993).
 
   Both `marker` and `mask` should point to two-dimensional arrays of
-  size (nrows, ncols) with the first dimension (nrows) changing
-  fastest. The `marker` array is updated with the result in-place.
+  size `dims` with the first listed dimension changing the
+  fastest. The distance between adjacent elements in the first and
+  second dimensions are given by the elements of `strides`. The
+  `marker` array is updated with the result in-place.
 
   The algorithm alternately scans the marker image in the forward and
   reverse directions performing a partial reconstruction in each

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -23,46 +23,47 @@
   The new marker pixel value is constrained to lie below the
   corresponding pixel in `mask`.
  */
-ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t nrows,
-                       ptrdiff_t ncols) {
+ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t dims[2],
+                       ptrdiff_t strides[2]) {
   // Offsets for the four neighbors
-  ptrdiff_t col_offset[4] = {-1, -1, -1, 0};
-  ptrdiff_t row_offset[4] = {1, 0, -1, -1};
+  ptrdiff_t i_offset[4] = {1, 0, -1, -1};
+  ptrdiff_t j_offset[4] = {-1, -1, -1, 0};
 
   ptrdiff_t count = 0;  // Number of modified pixels
 
-  for (ptrdiff_t p = 0; p < nrows * ncols; p++) {
-    ptrdiff_t col = p / nrows;
-    ptrdiff_t row = p % nrows;
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t p = i * strides[0] + j * strides[1];
 
-    // Compute the maximum of the marker at the current pixel and all
-    // of its previously visisted neighbors
-    float max_height = marker[p];
-    for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
-      ptrdiff_t neighbor_row = row + row_offset[neighbor];
-      ptrdiff_t neighbor_col = col + col_offset[neighbor];
+      // Compute the maximum of the marker at the current pixel and all
+      // of its previously visisted neighbors
+      float max_height = marker[p];
+      for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-      ptrdiff_t q = neighbor_col * nrows + neighbor_row;
+        ptrdiff_t q = neighbor_i * strides[0] + neighbor_j * strides[1];
 
-      // Skip pixels outside the boundary
-      if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
-          neighbor_col >= ncols) {
-        continue;
+        // Skip pixels outside the boundary
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
+          continue;
+        }
+
+        max_height = max_height > marker[q] ? max_height : marker[q];
       }
 
-      max_height = max_height > marker[q] ? max_height : marker[q];
-    }
+      // Set the marker at the current pixel to the minimum of the
+      // maximum height of the neighborhood and the mask at the current
+      // pixel.
 
-    // Set the marker at the current pixel to the minimum of the
-    // maximum height of the neighborhood and the mask at the current
-    // pixel.
+      float z = max_height < mask[p] ? max_height : mask[p];
 
-    float z = max_height < mask[p] ? max_height : mask[p];
-
-    if (z != marker[p]) {
-      // Increment count only if we change the current pixel
-      count++;
-      marker[p] = z;
+      if (z != marker[p]) {
+        // Increment count only if we change the current pixel
+        count++;
+        marker[p] = z;
+      }
     }
   }
   return count;
@@ -88,45 +89,46 @@ ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t nrows,
   The new marker pixel value is constrained to lie below the
   corresponding pixel in `mask`.
  */
-ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
-                        ptrdiff_t ncols) {
+ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t dims[2],
+                        ptrdiff_t strides[2]) {
   // Offsets for the four neighbors
-  ptrdiff_t col_offset[4] = {1, 1, 1, 0};
-  ptrdiff_t row_offset[4] = {-1, 0, 1, 1};
+  ptrdiff_t i_offset[4] = {-1, 0, 1, 1};
+  ptrdiff_t j_offset[4] = {1, 1, 1, 0};
 
   ptrdiff_t count = 0;  // Number of modified pixels
 
   // Note that the loop decreases. p must have a signed type for this
   // to work correctly.
-  for (ptrdiff_t p = nrows * ncols - 1; p >= 0; p--) {
-    ptrdiff_t col = p / nrows;
-    ptrdiff_t row = p % nrows;
+  for (ptrdiff_t j = dims[1] - 1; j >= 0; j--) {
+    for (ptrdiff_t i = dims[0] - 1; i >= 0; i--) {
+      ptrdiff_t p = i * strides[0] + j * strides[1];
 
-    // Compute the maximum of the marker at the current pixel and all
-    // of its previously visited neighbors
-    float max_height = marker[p];
-    for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
-      ptrdiff_t neighbor_row = row + row_offset[neighbor];
-      ptrdiff_t neighbor_col = col + col_offset[neighbor];
-      ptrdiff_t q = neighbor_col * nrows + neighbor_row;
+      // Compute the maximum of the marker at the current pixel and all
+      // of its previously visited neighbors
+      float max_height = marker[p];
+      for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
+        ptrdiff_t q = neighbor_i * strides[0] + neighbor_j * strides[1];
 
-      // Skip pixels outside the boundary
-      if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
-          neighbor_col >= ncols) {
-        continue;
+        // Skip pixels outside the boundary
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
+          continue;
+        }
+        max_height = max_height > marker[q] ? max_height : marker[q];
       }
-      max_height = max_height > marker[q] ? max_height : marker[q];
-    }
 
-    // Set the marker at the current pixel to the minimum of the
-    // maximum height of the neighborhood and the mask at the current
-    // pixel.
+      // Set the marker at the current pixel to the minimum of the
+      // maximum height of the neighborhood and the mask at the current
+      // pixel.
 
-    float z = max_height < mask[p] ? max_height : mask[p];
-    if (z != marker[p]) {
-      // Increment count only if we change the current pixel
-      count++;
-      marker[p] = z;
+      float z = max_height < mask[p] ? max_height : mask[p];
+      if (z != marker[p]) {
+        // Increment count only if we change the current pixel
+        count++;
+        marker[p] = z;
+      }
     }
   }
   return count;
@@ -153,13 +155,14 @@ ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
   Transactions on Image Processing, Vol. 2, No. 2.
   https://doi.org/10.1109/83.217222
  */
-void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols) {
-  ptrdiff_t n = ncols * nrows;
+void reconstruct(float *marker, float *mask, ptrdiff_t dims[2],
+                 ptrdiff_t strides[2]) {
+  ptrdiff_t n = dims[0] * dims[1];
 
   const int32_t max_iterations = 1000;
   for (int32_t iteration = 0; iteration < max_iterations && n > 0;
        iteration++) {
-    n = forward_scan(marker, mask, nrows, ncols);
-    n += backward_scan(marker, mask, nrows, ncols);
+    n = forward_scan(marker, mask, dims, strides);
+    n += backward_scan(marker, mask, dims, strides);
   }
 }

--- a/src/morphology/reconstruct.h
+++ b/src/morphology/reconstruct.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 
-void reconstruct(float *marker, float *mask, ptrdiff_t dims[2], ptrdiff_t strides[2]);
+void reconstruct(float *marker, float *mask, ptrdiff_t dims[2],
+                 ptrdiff_t strides[2]);
 
 #endif  // TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H

--- a/src/morphology/reconstruct.h
+++ b/src/morphology/reconstruct.h
@@ -3,6 +3,6 @@
 
 #include <stddef.h>
 
-void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols);
+void reconstruct(float *marker, float *mask, ptrdiff_t dims[2], ptrdiff_t strides[2]);
 
 #endif  // TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -368,17 +368,17 @@ int main(int argc, char *argv[]) {
   ptrdiff_t strided_cm_strides[2] = {3, 300};
 
   for (uint32_t test = 0; test < 50; test++) {
-    int32_t result = random_dem_test(cm_dims, cm_strides, test);
+    int32_t result = random_dem_test(cm_dims, cm_strides, 3 * test);
     if (result < 0) {
       return result;
     }
 
-    result = random_dem_test(rm_dims, rm_strides, 2 * test);
+    result = random_dem_test(rm_dims, rm_strides, 3 * test + 1);
     if (result < 0) {
       return result;
     }
 
-    result = random_dem_test(strided_cm_dims, strided_cm_strides, 3 * test);
+    result = random_dem_test(strided_cm_dims, strided_cm_strides, 3 * test + 2);
     if (result < 0) {
       return result;
     }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -37,7 +37,7 @@ int32_t test_fillsinks_filled(float *filled_dem, ptrdiff_t dims[2],
   ptrdiff_t j_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
 
   for (ptrdiff_t j = 0; j < dims[1]; j++) {
-    for (ptrdiff_t i = 0; i < dims[1]; i++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
       float z = filled_dem[i * strides[0] + j * strides[1]];
       ptrdiff_t up_neighbor_count = 0;
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
@@ -368,10 +368,12 @@ int main(int argc, char *argv[]) {
   ptrdiff_t strided_cm_strides[2] = {3, 300};
 
   for (uint32_t test = 0; test < 50; test++) {
-    int32_t result = random_dem_test(cm_dims, cm_strides, 3 * test);
+    int32_t result = 0;
+    result = random_dem_test(cm_dims, cm_strides, 3 * test);
     if (result < 0) {
       return result;
     }
+
 
     result = random_dem_test(rm_dims, rm_strides, 3 * test + 1);
     if (result < 0) {

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -355,6 +355,9 @@ int main(int argc, char *argv[]) {
   ptrdiff_t rm_dims[2] = {200, 100};
   ptrdiff_t rm_strides[2] = {1, 200};
 
+  ptrdiff_t strided_cm_dims[2] = {100, 200};
+  ptrdiff_t strided_cm_strides[2] = {3, 300};
+
   for (uint32_t test = 0; test < 50; test++) {
     int32_t result = random_dem_test(cm_dims, cm_strides, test);
     if (result < 0) {
@@ -362,6 +365,11 @@ int main(int argc, char *argv[]) {
     }
 
     result = random_dem_test(rm_dims, rm_strides, 2 * test);
+    if (result < 0) {
+      return result;
+    }
+
+    result = random_dem_test(strided_cm_dims, strided_cm_strides, 3 * test);
     if (result < 0) {
       return result;
     }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -347,11 +347,19 @@ int32_t random_dem_test(ptrdiff_t dims[2], ptrdiff_t strides[2], uint32_t seed) 
 }
 
 int main(int argc, char *argv[]) {
-  ptrdiff_t dims[2] = {100,200};
-  ptrdiff_t strides[2] = {1, 100};
+  ptrdiff_t cm_dims[2] = {100,200};
+  ptrdiff_t cm_strides[2] = {1, 100};
 
-  for (uint32_t test = 0; test < 100; test++) {
-    int32_t result = random_dem_test(dims, strides, test);
+  ptrdiff_t rm_dims[2] = {200,100};
+  ptrdiff_t rm_strides[2] = {1, 200};
+
+  for (uint32_t test = 0; test < 50; test++) {
+    int32_t result = random_dem_test(cm_dims, cm_strides, test);
+    if (result < 0) {
+      return result;
+    }
+
+    result = random_dem_test(rm_dims,rm_strides,2 * test);
     if (result < 0) {
       return result;
     }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -283,7 +283,9 @@ int32_t test_gwdt(float *dist, ptrdiff_t *prev, float *costs, int32_t *flats,
   return 0;
 }
 
-int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
+int32_t random_dem_test(ptrdiff_t dims[2], ptrdiff_t strides[2], uint32_t seed) {
+  ptrdiff_t nrows = dims[0];
+  ptrdiff_t ncols = dims[1];
   // Allocate variables
 
   // Input DEM
@@ -312,7 +314,7 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
   }
 
   // Run flow routing algorithms
-  fillsinks(filled_dem, dem, nrows, ncols);
+  fillsinks(filled_dem, dem, dims, strides);
 
   test_fillsinks_ge(dem, filled_dem, nrows, ncols);
   test_fillsinks_filled(filled_dem, nrows, ncols);
@@ -345,11 +347,11 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
 }
 
 int main(int argc, char *argv[]) {
-  ptrdiff_t nrows = 100;
-  ptrdiff_t ncols = 200;
+  ptrdiff_t dims[2] = {100,200};
+  ptrdiff_t strides[2] = {1, 100};
 
   for (uint32_t test = 0; test < 100; test++) {
-    int32_t result = random_dem_test(nrows, ncols, test);
+    int32_t result = random_dem_test(dims, strides, test);
     if (result < 0) {
       return result;
     }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -291,23 +291,32 @@ int32_t random_dem_test(ptrdiff_t dims[2], ptrdiff_t strides[2],
   // Allocate variables
 
   // Input DEM
-  float *dem = new float[dims[0] * dims[1]];
+  float *dem =
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
 
   // Output for fillsinks
-  float *filled_dem = new float[dims[0] * dims[1]];
+  float *filled_dem =
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
 
   // Output for identifyflats
-  int32_t *flats = new int32_t[dims[0] * dims[1]];
+  int32_t *flats =
+      new int32_t[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
 
   // Outputs for compute_costs
-  ptrdiff_t *conncomps = new ptrdiff_t[dims[0] * dims[1]];
-  float *costs = new float[dims[0] * dims[1]];
+  ptrdiff_t *conncomps = new ptrdiff_t[(dims[0] - 1) * strides[0] +
+                                       (dims[1] - 1) * strides[1] + 1];
+  float *costs =
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
 
   // Outputs and intermediate needs for gwdt
-  float *dist = new float[dims[0] * dims[1]];
-  ptrdiff_t *heap = new ptrdiff_t[dims[0] * dims[1]];
-  ptrdiff_t *back = new ptrdiff_t[dims[0] * dims[1]];
-  ptrdiff_t *prev = new ptrdiff_t[dims[0] * dims[1]];
+  float *dist =
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
+  ptrdiff_t *heap = new ptrdiff_t[(dims[0] - 1) * strides[0] +
+                                  (dims[1] - 1) * strides[1] + 1];
+  ptrdiff_t *back = new ptrdiff_t[(dims[0] - 1) * strides[0] +
+                                  (dims[1] - 1) * strides[1] + 1];
+  ptrdiff_t *prev = new ptrdiff_t[(dims[0] - 1) * strides[0] +
+                                  (dims[1] - 1) * strides[1] + 1];
 
   for (uint32_t j = 0; j < dims[1]; j++) {
     for (uint32_t i = 0; i < dims[0]; i++) {

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -292,31 +292,31 @@ int32_t random_dem_test(ptrdiff_t dims[2], ptrdiff_t strides[2],
 
   // Input DEM
   float *dem =
-      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1]();
 
   // Output for fillsinks
   float *filled_dem =
-      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1]();
 
   // Output for identifyflats
-  int32_t *flats =
-      new int32_t[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
+  int32_t *flats = new int32_t[(dims[0] - 1) * strides[0] +
+                               (dims[1] - 1) * strides[1] + 1]();
 
   // Outputs for compute_costs
   ptrdiff_t *conncomps = new ptrdiff_t[(dims[0] - 1) * strides[0] +
-                                       (dims[1] - 1) * strides[1] + 1];
+                                       (dims[1] - 1) * strides[1] + 1]();
   float *costs =
-      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1]();
 
   // Outputs and intermediate needs for gwdt
   float *dist =
-      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1];
+      new float[(dims[0] - 1) * strides[0] + (dims[1] - 1) * strides[1] + 1]();
   ptrdiff_t *heap = new ptrdiff_t[(dims[0] - 1) * strides[0] +
-                                  (dims[1] - 1) * strides[1] + 1];
+                                  (dims[1] - 1) * strides[1] + 1]();
   ptrdiff_t *back = new ptrdiff_t[(dims[0] - 1) * strides[0] +
-                                  (dims[1] - 1) * strides[1] + 1];
+                                  (dims[1] - 1) * strides[1] + 1]();
   ptrdiff_t *prev = new ptrdiff_t[(dims[0] - 1) * strides[0] +
-                                  (dims[1] - 1) * strides[1] + 1];
+                                  (dims[1] - 1) * strides[1] + 1]();
 
   for (uint32_t j = 0; j < dims[1]; j++) {
     for (uint32_t i = 0; i < dims[0]; i++) {

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -374,7 +374,6 @@ int main(int argc, char *argv[]) {
       return result;
     }
 
-
     result = random_dem_test(rm_dims, rm_strides, 3 * test + 1);
     if (result < 0) {
       return result;


### PR DESCRIPTION
Addresses #23 

This is a breaking change, because the interface to `fillsinks` has changed. It is currently a draft PR, because I want to make sure that all the places where we are already using `fillsinks` are building tagged versions of libtopotoolbox before merging this into the main branch (i.e pytopotoolbox, @Teschl, and TTLEM3D, @wschwanghart). I think I will update all of the existing libtopotoolbox API to use similar interfaces and then merge them all at once. I would also like to add a documentation page describing the expected memory layout of arrays passed to libtopotoolbox in the style of [FFTW](http://fftw.org/fftw3_doc/Multi_002ddimensional-Array-Format.html#Multi_002ddimensional-Array-Format), for example. 

I also need to change the libtopotoolbox command line tool tutorial to use the new interface.

# Changes

This PR changes the interface of `fillsinks` to 

```C
void fillsinks(float *output, float *dem, ptrdiff_t dims[2], ptrdiff_t strides[2]);
```

from

```C
void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
```

The `dims` and `strides` arguments are 2 element arrays that give the number of elements in each dimension and the spacing between adjacent elements in each dimension, respectively.

Contiguous column-major arrays, like we have been using previously in libtopotoolbox, have

```C
ptrdiff_t dims[2] = {nrows,ncols};
ptrdiff_t strides[2] = {1, nrows};
```

Contiguous row-major arrays would have

```C
ptrdiff_t dims[2] = {ncols, nrows};
ptrdiff_t strides[2] = {1, ncols};
```

Note that the dimensions are flipped, and `strides[1] == dims[0]` in both cases. You can switch between column- and row-major in libtopotoolbox already, simply by interchanging the order of the dimensions. This does lead to a situation, however, where you must pass the number of columns to a function argument called `nrows`. At the very least, the names used in the new interface should make this less confusing.

It is also possible to operate on a row-major array by adjusting the strides

```C
ptrdiff_t dims[2] = {nrows, ncols};
ptrdiff_t strides[2] = {ncols, 1};
```

but this will perform terribly because internally the functions loop over `dims[1]` first and then `dims[0]`. If the indices of the second dimension change most quickly, then this array access pattern is very unfriendly to the cache.

The real value of the `strides` argument is that it enables operating on non-contiguous arrays and subsets of arrays. For example, in `excesstopography_fmm3d`, which is used in TTLEM3D, the lithology stack is represented as a three-dimensional array of size `nlayers` x `nrows` x `ncols`. If you wanted to apply a function like `fillsinks` to the first layer of the lithology stack, you could set

```C
ptrdiff_t dims[2] = {nrows, ncols};
ptrdiff_t strides[2] = {nlayers, nrows * nlayers};
```

If you wanted to apply `fillsinks` to a subset of size `subset_rows` x `subset_cols` of a DEM of size `nrows` x `ncols`, you could set

```C
ptrdiff_t dims[2] = {subset_rows, subset_cols};
ptrdiff_t strides[2] = {1, nrows};
float *subset = dem + offset;
```
You would also have to calculate the offset of the start of the array.

The tests of `fillsinks` now run on a few different memory layouts.

# How to migrate

To migrate an application using the new interface, it is probably easier to create the `dims` and `strides` arguments in the C bindings rather than creating a pair or a two-element array in the host language and trying to pass that to C. For example, in the C file that implements a `mexFunction` for MATLAB, you might do something like

```
// ...
ptrdiff_t dims[2] = {mxGetM(prhs[0]), mxGetN(prhs[0])};
ptrdiff_t strides[2] = {1, dims[0]};
// ...
```

since MATLAB arrays are typically column-major. 

You might need to do some logic to figure out what the appropriate strides or dimensions are. Numpy arrays can be stored in either row- or column-major layout, so one might need to extract that information from the `py_array_t` object passed to `wrap_fillsinks`.