### PR TITLE
Pass `dims` to functions

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -44,11 +44,11 @@ int has_topotoolbox(void);
 
    @param[out] output The filled DEM
    @param[in]  dem    The input DEM
-   @param[in]  nrows  The size of both DEMs in the fastest changing dimension
-   @param[in]  ncols  The size of both DEMs in the slowest changing dimension
+   @param[in]  dims   The dimensions of both DEMs with the fastest changing
+                      dimension first
  */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
 
 /**
    @brief Labels flat, sill and presill pixels in the provided DEM
@@ -83,12 +83,11 @@ void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols);
 
    @param[out] output The integer-valued output array with pixel labels
    @param[in]  dem    The input DEM
-   @param[in]  nrows  The size of both DEMs in the fastest changing dimension
-   @param[in]  ncols  The size of both DEMs in the slowest changing dimension
+   @param[in]  dims   The dimensions of both DEMs with the fastest changing
+                      dimension first
  */
 TOPOTOOLBOX_API
-ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
-                        ptrdiff_t ncols);
+ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t dims[2]);
 
 /**
   @brief Compute costs for the gray-weighted distance transform
@@ -114,13 +113,13 @@ ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
   @param[in]  flats        Array identifying the flat pixels
   @param[in]  original_dem The DEM prior to sink filling
   @param[in]  filled_dem   The DEM after sink filling
-  @param[in]  nrows  The size of both DEMs in the fastest changing dimension
-  @param[in]  ncols  The size of both DEMs in the slowest changing dimension
+  @param[in]  dims         The dimensions of both DEMs with the fastest changing
+                           dimension first
  */
 TOPOTOOLBOX_API
 void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
-                       float *original_dem, float *filled_dem, ptrdiff_t nrows,
-                       ptrdiff_t ncols);
+                       float *original_dem, float *filled_dem,
+                       ptrdiff_t dims[2]);
 
 /**
    @brief Compute the gray-weighted distance transform
@@ -143,30 +142,27 @@ void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
    time. Pattern Recognition Letters 15, 1235-1240.
 
    @param[out] dist             The computed gray-weighted distance transform.
-                                A float array of size (nrows x ncols).
+                                A float array of size (dims[0] x dims[1]).
    @param[out] prev             Backlinks to the previous pixel along the
-                                geodesic path. A ptrdiff_t array of size (nrows
-                                x ncols). If backlinks are not required, a null
-                                pointer can be passed here: it is checked for
-                                NULL before being accessed.
+                                geodesic path. A ptrdiff_t array of size
+   (dims[0] x dims[1]). If backlinks are not required, a null pointer can be
+   passed here: it is checked for NULL before being accessed.
    @param[in]  costs            The input costs as computed by
                                 gwdt_computecosts().
-                                A float array of size (nrows x ncols).
+                                A float array of size (dims[0] x dims[1]).
    @param[in]  flats            Array identifying the flat and presill pixels
                                 using the encoding of identifyflats(). An
-                                int32_t array of size (nrows x ncols).
-   @param[in]  heap             A ptrdiff_t array of indices (nrows x ncols)
+                                int32_t array of size (dims[0] x dims[1]).
+   @param[in]  heap             A ptrdiff_t array of indices (dims[0] x dims[1])
                                 used for implementing the priority queue.
-   @param[in]  back             A ptrdiff_t array of indices (nrows x ncols)
+   @param[in]  back             A ptrdiff_t array of indices (dims[0] x dims[1])
                                 used for implementing the priority queue.
-   @param[in]  nrows            The size of the input and output arrays in the
-                                fastest changing dimension
-   @param[in]  ncols            The size of the input and output arrays in the
-                                slowest changing dimension
+   @param[in]  dims             The dimensions of both DEMs with the fastest
+                                changing dimension first
  */
 TOPOTOOLBOX_API
 void gwdt(float *dist, ptrdiff_t *prev, float *costs, int32_t *flats,
-          ptrdiff_t *heap, ptrdiff_t *back, ptrdiff_t nrows, ptrdiff_t ncols);
+          ptrdiff_t *heap, ptrdiff_t *back, ptrdiff_t dims[2]);
 
 /**
  @brief Compute excess topography with 2D varying threshold slopes
@@ -207,24 +203,20 @@ void gwdt(float *dist, ptrdiff_t *prev, float *costs, int32_t *flats,
  @param[out] excess           The solution of the constrained eikonal equation.
                               To compute the excess topography, subtract this
                               array elementwise from the DEM. A float array of
-                              size (nrows x ncols).
+                              size (dims[0] x dims[1]).
  @param[in]  dem              The input digital elevation model. A float array
-                              of size (nrows x ncols).
+                              of size (dims[0] x dims[1]).
  @param[in]  threshold_slopes The threshold slopes (tangent of the critical
                               angle) at each grid cell. A float array of size
-                              (nrows x ncols).
+                              (dims[0] x dims[1]).
  @param[in]  cellsize         The spacing between grid cells, assumed to be
                               constant and identical in the x- and y- directions
- @param[in]  nrows            The size of the input and output DEMs and the
-                              threshold_slopes array in the fastest changing
-                              dimension
- @param[in]  ncols            The size of the input and output DEMs and the
-                              threshold_slopes array in the slowest changing
-                              dimension
+ @param[in]  dims             The dimensions of both DEMs with the fastest
+                              changing dimension first
  */
 TOPOTOOLBOX_API
 void excesstopography_fsm2d(float *excess, float *dem, float *threshold_slopes,
-                            float cellsize, ptrdiff_t nrows, ptrdiff_t ncols);
+                            float cellsize, ptrdiff_t dims[2]);
 
 /**
  @brief Compute excess topography with 2D varying threshold slopes
@@ -266,29 +258,25 @@ void excesstopography_fsm2d(float *excess, float *dem, float *threshold_slopes,
  @param[out] excess           The solution of the constrained eikonal equation.
                               To compute the excess topography, subtract this
                               array elementwise from the DEM. A float array of
-                              size (nrows x ncols).
- @param[in]  heap             A ptrdiff_t array of indices (nrows x ncols) used
-                              for implementing the priority queue.
- @param[in]  back             A ptrdiff_t array of indices (nrows x ncols) used
-                              for implementing the priority queue.
+                              size (dims[0] x dims[1]).
+ @param[in]  heap             A ptrdiff_t array of indices (dims[0] x dims[1])
+ used for implementing the priority queue.
+ @param[in]  back             A ptrdiff_t array of indices (dims[0] x dims[1])
+ used for implementing the priority queue.
  @param[in]  dem              The input digital elevation model. A float array
-                              of size (nrows x ncols).
+                              of size (dims[0] x dims[1]).
  @param[in]  threshold_slopes The threshold slopes (tangent of the critical
                               angle) at each grid cell. A float array of size
-                              (nrows x ncols).
+                              (dims[0] x dims[1]).
  @param[in]  cellsize         The spacing between grid cells, assumed to be
                               constant and identical in the x- and y- directions
- @param[in]  nrows            The size of the input and output DEMs and the
-                              threshold_slopes array in the fastest changing
-                              dimension
- @param[in]  ncols            The size of the input and output DEMs and the
-                              threshold_slopes array in the slowest changing
-                              dimension
+ @param[in]  dims             The dimensions of both DEMs with the fastest
+                              changing dimension first
  */
 TOPOTOOLBOX_API
 void excesstopography_fmm2d(float *excess, ptrdiff_t *heap, ptrdiff_t *back,
                             float *dem, float *threshold_slopes, float cellsize,
-                            ptrdiff_t nrows, ptrdiff_t ncols);
+                            ptrdiff_t dims[2]);
 
 /**
  @brief Compute excess topography with three-dimensionally variable
@@ -317,29 +305,25 @@ void excesstopography_fmm2d(float *excess, ptrdiff_t *heap, ptrdiff_t *back,
  @param[out] excess           The solution of the constrained eikonal equation.
                               To compute the excess topography, subtract this
                               array elementwise from the DEM. A float array of
-                              size (nrows x ncols).
- @param[in]  heap             A ptrdiff_t array of indices (nrows x ncols) used
-                              for implementing the priority queue.
- @param[in]  back             A ptrdiff_t array of indices (nrows x ncols) used
-                              for implementing the priority queue.
+                              size (dims[0] x dims[1]).
+ @param[in]  heap             A ptrdiff_t array of indices (dims[0] x dims[1])
+ used for implementing the priority queue.
+ @param[in]  back             A ptrdiff_t array of indices (dims[0] x dims[1])
+ used for implementing the priority queue.
  @param[in]  dem              The input digital elevation model. A float array
-                              of size (nrows x ncols).
+                              of size (dims[0] x dims[1]).
  @param[in] lithstack         The input lithology. A three-dimensional float
-                              array of size (nlayers x nrows x ncols). The value
-                              of `lithstack[layer,row,col]` is the elevation of
-                              the top surface of the given layer. Note that the
-                              first dimension is the layer, so that the layers
-                              of each cell are stored contiguously.
+                              array of size (nlayers x dims[0] x dims[1]). The
+ value of `lithstack[layer,row,col]` is the elevation of the top surface of the
+ given layer. Note that the first dimension is the layer, so that the layers of
+ each cell are stored contiguously.
  @param[in]  threshold_slopes The threshold slopes (tangent of the critical
                               angle) for each layer. A float array of size
                               (nlayers).
  @param[in]  cellsize         The spacing between grid cells, assumed to be
                               constant and identical in the x- and y- directions
- @param[in]  nrows            The size of the input and output DEMs in the
-                              fastest changing dimension.
- @param[in]  ncols            The size of the input and output DEMs and the
-                              in the slowest changing
-                              dimension.
+ @param[in]  dims             The dimensions of both DEMs with the fastest
+                              changing dimension first
  @param[in]  nlayers          The number of layers in the lithstack and
                               threshold_slopes arrays.
  */
@@ -347,7 +331,6 @@ TOPOTOOLBOX_API
 void excesstopography_fmm3d(float *excess, ptrdiff_t *heap, ptrdiff_t *back,
                             float *dem, float *lithstack,
                             float *threshold_slopes, float cellsize,
-                            ptrdiff_t nrows, ptrdiff_t ncols,
-                            ptrdiff_t nlayers);
+                            ptrdiff_t dims[2], ptrdiff_t nlayers);
 
 #endif  // TOPOTOOLBOX_H

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -21,30 +21,29 @@
   Sinks are filled using grayscale morphological reconstruction.
 */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t nrows, ptrdiff_t ncols) {
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
+void fillsinks(float *output, float *dem, ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
       // Invert the DEM
-      dem[col * nrows + row] *= -1.0;
+      dem[j * dims[0] + i] *= -1.0;
 
       // Set the boundary pixels of the output equal to the DEM and
       // the interior pixels equal to -INFINITY.
-      if ((row == 0 || row == (nrows - 1)) ||
-          (col == 0 || col == (ncols - 1))) {
-        output[col * nrows + row] = dem[col * nrows + row];
+      if ((i == 0 || i == (dims[0] - 1)) || (j == 0 || j == (dims[1] - 1))) {
+        output[j * dims[0] + i] = dem[j * dims[0] + i];
       } else {
-        output[col * nrows + row] = -INFINITY;
+        output[j * dims[0] + i] = -INFINITY;
       }
     }
   }
 
-  reconstruct(output, dem, nrows, ncols);
+  reconstruct(output, dem, dims);
 
   // Revert the DEM and the output
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
-      dem[col * nrows + row] *= -1.0;
-      output[col * nrows + row] *= -1.0;
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      dem[j * dims[0] + i] *= -1.0;
+      output[j * dims[0] + i] *= -1.0;
     }
   }
 }

--- a/src/identifyflats.c
+++ b/src/identifyflats.c
@@ -9,7 +9,7 @@
   Identify flat regions and sills in a digital elevation model.
 
   The arrays pointed to by `output` and `dem` should represent
-  two-dimensional arrays of size (nrows, ncols). The output is a
+  two-dimensional arrays of size (dims[0], dims[1]). The output is a
   bitfield where
 
   Bit 0 is set if the pixel is a flat
@@ -29,44 +29,43 @@
   output[p] & 4
  */
 TOPOTOOLBOX_API
-ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
-                        ptrdiff_t ncols) {
-  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
-  ptrdiff_t row_offset[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
+ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t dims[2]) {
+  ptrdiff_t j_offset[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
+  ptrdiff_t i_offset[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
 
   ptrdiff_t count_flats = 0;
 
   // A flat is a pixel whose elevation is equal to the minimum
   // elevation of all of its neighbors.
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
       // Zero the output for all non-flat/sill pixels
-      output[col * nrows + row] = 0;
+      output[j * dims[0] + i] = 0;
 
       // Skip border pixels
-      if (col == 0 || col == ncols - 1 || row == 0 || row == nrows - 1) {
+      if (j == 0 || j == dims[1] - 1 || i == 0 || i == dims[0] - 1) {
         continue;
       }
 
-      float dem_height = dem[col * nrows + row];
+      float dem_height = dem[j * dims[0] + i];
       float min_height = dem_height;
 
       // Compute the minimum height in the neighborhood around the
       // current pixel
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
-        ptrdiff_t neighbor_row = row + row_offset[neighbor];
-        ptrdiff_t neighbor_col = col + col_offset[neighbor];
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-        // neighbor_row and neighbor_col are valid indices because we
+        // neighbor_i and neighbor_j are valid indices because we
         // skipped border pixels above
-        float neighbor_height = dem[neighbor_col * nrows + neighbor_row];
+        float neighbor_height = dem[neighbor_j * dims[0] + neighbor_i];
         min_height =
             min_height < neighbor_height ? min_height : neighbor_height;
       }
 
       if (dem_height == min_height) {
         // Pixel is a flat
-        output[col * nrows + row] |= 1;
+        output[j * dims[0] + i] |= 1;
         count_flats++;
       }
     }
@@ -76,38 +75,38 @@ ptrdiff_t identifyflats(int32_t *output, float *dem, ptrdiff_t nrows,
   // 1. is not a flat
   // 2. borders at least one flat
   // 3. has the same elevation as a flat that it touches
-  for (ptrdiff_t col = 0; col < ncols; col++) {
-    for (ptrdiff_t row = 0; row < nrows; row++) {
-      if (output[col * nrows + row] & 1) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      if (output[j * dims[0] + i] & 1) {
         // Pixel is a flat, skip it
         continue;
       }
 
-      float dem_height = dem[col * nrows + row];
+      float dem_height = dem[j * dims[0] + i];
 
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
-        ptrdiff_t neighbor_row = row + row_offset[neighbor];
-        ptrdiff_t neighbor_col = col + col_offset[neighbor];
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-        if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
-            neighbor_col >= ncols) {
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
           // Skip neighbors outside the image
           continue;
         }
 
-        if (!(output[neighbor_col * nrows + neighbor_row] & 1)) {
+        if (!(output[neighbor_j * dims[0] + neighbor_i] & 1)) {
           // Neighbor is not a flat, skip it
           continue;
         }
 
-        float neighbor_height = dem[neighbor_col * nrows + neighbor_row];
+        float neighbor_height = dem[neighbor_j * dims[0] + neighbor_i];
         if (neighbor_height == dem_height) {
           // flat neighbor has a height equal to that of the current pixel.
           // Current pixel is a sill
-          output[col * nrows + row] |= 2;
+          output[j * dims[0] + i] |= 2;
 
           // Neighboring pixel is a presill
-          output[neighbor_col * nrows + neighbor_row] |= 4;
+          output[neighbor_j * dims[0] + neighbor_i] |= 4;
           continue;
         }
       }

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -23,46 +23,46 @@
   The new marker pixel value is constrained to lie below the
   corresponding pixel in `mask`.
  */
-ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t nrows,
-                       ptrdiff_t ncols) {
+ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t dims[2]) {
   // Offsets for the four neighbors
-  ptrdiff_t col_offset[4] = {-1, -1, -1, 0};
-  ptrdiff_t row_offset[4] = {1, 0, -1, -1};
+  ptrdiff_t j_offset[4] = {-1, -1, -1, 0};
+  ptrdiff_t i_offset[4] = {1, 0, -1, -1};
 
   ptrdiff_t count = 0;  // Number of modified pixels
 
-  for (ptrdiff_t p = 0; p < nrows * ncols; p++) {
-    ptrdiff_t col = p / nrows;
-    ptrdiff_t row = p % nrows;
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t p = j * dims[0] + i;
 
-    // Compute the maximum of the marker at the current pixel and all
-    // of its previously visisted neighbors
-    float max_height = marker[p];
-    for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
-      ptrdiff_t neighbor_row = row + row_offset[neighbor];
-      ptrdiff_t neighbor_col = col + col_offset[neighbor];
+      // Compute the maximum of the marker at the current pixel and all
+      // of its previously visisted neighbors
+      float max_height = marker[p];
+      for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-      ptrdiff_t q = neighbor_col * nrows + neighbor_row;
+        ptrdiff_t q = neighbor_j * dims[0] + neighbor_i;
 
-      // Skip pixels outside the boundary
-      if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
-          neighbor_col >= ncols) {
-        continue;
+        // Skip pixels outside the boundary
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
+          continue;
+        }
+
+        max_height = max_height > marker[q] ? max_height : marker[q];
       }
 
-      max_height = max_height > marker[q] ? max_height : marker[q];
-    }
+      // Set the marker at the current pixel to the minimum of the
+      // maximum height of the neighborhood and the mask at the current
+      // pixel.
 
-    // Set the marker at the current pixel to the minimum of the
-    // maximum height of the neighborhood and the mask at the current
-    // pixel.
+      float z = max_height < mask[p] ? max_height : mask[p];
 
-    float z = max_height < mask[p] ? max_height : mask[p];
-
-    if (z != marker[p]) {
-      // Increment count only if we change the current pixel
-      count++;
-      marker[p] = z;
+      if (z != marker[p]) {
+        // Increment count only if we change the current pixel
+        count++;
+        marker[p] = z;
+      }
     }
   }
   return count;
@@ -88,45 +88,45 @@ ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t nrows,
   The new marker pixel value is constrained to lie below the
   corresponding pixel in `mask`.
  */
-ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
-                        ptrdiff_t ncols) {
+ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t dims[2]) {
   // Offsets for the four neighbors
-  ptrdiff_t col_offset[4] = {1, 1, 1, 0};
-  ptrdiff_t row_offset[4] = {-1, 0, 1, 1};
+  ptrdiff_t j_offset[4] = {1, 1, 1, 0};
+  ptrdiff_t i_offset[4] = {-1, 0, 1, 1};
 
   ptrdiff_t count = 0;  // Number of modified pixels
 
   // Note that the loop decreases. p must have a signed type for this
   // to work correctly.
-  for (ptrdiff_t p = nrows * ncols - 1; p >= 0; p--) {
-    ptrdiff_t col = p / nrows;
-    ptrdiff_t row = p % nrows;
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t p = j * dims[0] + i;
 
-    // Compute the maximum of the marker at the current pixel and all
-    // of its previously visited neighbors
-    float max_height = marker[p];
-    for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
-      ptrdiff_t neighbor_row = row + row_offset[neighbor];
-      ptrdiff_t neighbor_col = col + col_offset[neighbor];
-      ptrdiff_t q = neighbor_col * nrows + neighbor_row;
+      // Compute the maximum of the marker at the current pixel and all
+      // of its previously visited neighbors
+      float max_height = marker[p];
+      for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
+        ptrdiff_t q = neighbor_j * dims[0] + neighbor_i;
 
-      // Skip pixels outside the boundary
-      if (neighbor_row < 0 || neighbor_row >= nrows || neighbor_col < 0 ||
-          neighbor_col >= ncols) {
-        continue;
+        // Skip pixels outside the boundary
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
+          continue;
+        }
+        max_height = max_height > marker[q] ? max_height : marker[q];
       }
-      max_height = max_height > marker[q] ? max_height : marker[q];
-    }
 
-    // Set the marker at the current pixel to the minimum of the
-    // maximum height of the neighborhood and the mask at the current
-    // pixel.
+      // Set the marker at the current pixel to the minimum of the
+      // maximum height of the neighborhood and the mask at the current
+      // pixel.
 
-    float z = max_height < mask[p] ? max_height : mask[p];
-    if (z != marker[p]) {
-      // Increment count only if we change the current pixel
-      count++;
-      marker[p] = z;
+      float z = max_height < mask[p] ? max_height : mask[p];
+      if (z != marker[p]) {
+        // Increment count only if we change the current pixel
+        count++;
+        marker[p] = z;
+      }
     }
   }
   return count;
@@ -140,7 +140,7 @@ ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
   (1993).
 
   Both `marker` and `mask` should point to two-dimensional arrays of
-  size (nrows, ncols) with the first dimension (nrows) changing
+  size (dims[0], dims[1]) with the first dimension (dims[0]) changing
   fastest. The `marker` array is updated with the result in-place.
 
   The algorithm alternately scans the marker image in the forward and
@@ -153,13 +153,13 @@ ptrdiff_t backward_scan(float *marker, float *mask, ptrdiff_t nrows,
   Transactions on Image Processing, Vol. 2, No. 2.
   https://doi.org/10.1109/83.217222
  */
-void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols) {
-  ptrdiff_t n = ncols * nrows;
+void reconstruct(float *marker, float *mask, ptrdiff_t dims[2]) {
+  ptrdiff_t n = dims[0] * dims[1];
 
   const int32_t max_iterations = 1000;
   for (int32_t iteration = 0; iteration < max_iterations && n > 0;
        iteration++) {
-    n = forward_scan(marker, mask, nrows, ncols);
-    n += backward_scan(marker, mask, nrows, ncols);
+    n = forward_scan(marker, mask, dims);
+    n += backward_scan(marker, mask, dims);
   }
 }

--- a/src/morphology/reconstruct.h
+++ b/src/morphology/reconstruct.h
@@ -3,6 +3,6 @@
 
 #include <stddef.h>
 
-void reconstruct(float *marker, float *mask, ptrdiff_t nrows, ptrdiff_t ncols);
+void reconstruct(float *marker, float *mask, ptrdiff_t dims[2]);
 
 #endif  // TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H

--- a/test/excesstopography.cpp
+++ b/test/excesstopography.cpp
@@ -11,19 +11,19 @@ extern "C" {
 }
 
 float upwind_gradient(float *u, ptrdiff_t row, ptrdiff_t col, float cellsize,
-                      ptrdiff_t nrows, ptrdiff_t ncols) {
+                      ptrdiff_t dims[2]) {
   float north_gradient =
-      (u[col * nrows + row] - u[col * nrows + row - 1]) / cellsize;
+      (u[col * dims[0] + row] - u[col * dims[0] + row - 1]) / cellsize;
   float south_gradient =
-      (u[col * nrows + row + 1] - u[col * nrows + row]) / cellsize;
+      (u[col * dims[0] + row + 1] - u[col * dims[0] + row]) / cellsize;
 
   float ns_gradient =
       std::fmaxf(0.0f, std::fmaxf(north_gradient, -south_gradient));
 
   float west_gradient =
-      (u[col * nrows + row] - u[(col - 1) * nrows + row]) / cellsize;
+      (u[col * dims[0] + row] - u[(col - 1) * dims[0] + row]) / cellsize;
   float east_gradient =
-      (u[(col + 1) * nrows + row] - u[col * nrows + row]) / cellsize;
+      (u[(col + 1) * dims[0] + row] - u[col * dims[0] + row]) / cellsize;
 
   float ew_gradient =
       std::fmaxf(0.0f, std::fmaxf(west_gradient, -east_gradient));
@@ -32,23 +32,22 @@ float upwind_gradient(float *u, ptrdiff_t row, ptrdiff_t col, float cellsize,
   return g;
 }
 
-int32_t test_excess_constraint(float *excess, float *dem, ptrdiff_t nrows,
-                               ptrdiff_t ncols) {
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      assert(excess[i + j * nrows] <= dem[i + j * nrows]);
+int32_t test_excess_constraint(float *excess, float *dem, ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      assert(excess[i + j * dims[0]] <= dem[i + j * dims[0]]);
     }
   }
   return 0;
 }
 
 int32_t test_upwind_gradient(float *excess, float *threshold, float cellsize,
-                             ptrdiff_t nrows, ptrdiff_t ncols) {
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      if ((i > 0) && (i < nrows - 1) && (j > 0) && (j < ncols - 1)) {
-        assert(upwind_gradient(excess, i, j, cellsize, nrows, ncols) -
-                   threshold[j * nrows + i] <
+                             ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      if ((i > 0) && (i < dims[0] - 1) && (j > 0) && (j < dims[1] - 1)) {
+        assert(upwind_gradient(excess, i, j, cellsize, dims) -
+                   threshold[j * dims[0] + i] <
                1e-4);
       }
     }
@@ -56,32 +55,31 @@ int32_t test_upwind_gradient(float *excess, float *threshold, float cellsize,
   return 0;
 }
 
-int32_t test_excess_isfinite(float *excess, ptrdiff_t nrows, ptrdiff_t ncols) {
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      assert(excess[i + j * nrows] != INFINITY);
+int32_t test_excess_isfinite(float *excess, ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      assert(excess[i + j * dims[0]] != INFINITY);
     }
   }
   return 0;
 }
 
-int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, ptrdiff_t nlayers,
-                        uint32_t seed) {
-  float *dem = new float[nrows * ncols];
-  float *fmm_excess = new float[nrows * ncols];
-  float *fsm_excess = new float[nrows * ncols];
-  float *fmm_excess3d = new float[nrows * ncols];
-  float *lithstack = new float[nlayers * nrows * ncols];
+int32_t random_dem_test(ptrdiff_t dims[2], ptrdiff_t nlayers, uint32_t seed) {
+  float *dem = new float[dims[0] * dims[1]];
+  float *fmm_excess = new float[dims[0] * dims[1]];
+  float *fsm_excess = new float[dims[0] * dims[1]];
+  float *fmm_excess3d = new float[dims[0] * dims[1]];
+  float *lithstack = new float[nlayers * dims[0] * dims[1]];
   float *threshold_slopes3d = new float[nlayers];
-  ptrdiff_t *heap = new ptrdiff_t[nrows * ncols];
-  ptrdiff_t *heap3d = new ptrdiff_t[nrows * ncols];
-  ptrdiff_t *back = new ptrdiff_t[nrows * ncols];
-  ptrdiff_t *back3d = new ptrdiff_t[nrows * ncols];
-  float *threshold = new float[nrows * ncols];
+  ptrdiff_t *heap = new ptrdiff_t[dims[0] * dims[1]];
+  ptrdiff_t *heap3d = new ptrdiff_t[dims[0] * dims[1]];
+  ptrdiff_t *back = new ptrdiff_t[dims[0] * dims[1]];
+  ptrdiff_t *back3d = new ptrdiff_t[dims[0] * dims[1]];
+  float *threshold = new float[dims[0] * dims[1]];
 
-  for (uint32_t col = 0; col < ncols; col++) {
-    for (uint32_t row = 0; row < nrows; row++) {
-      ptrdiff_t idx = col * nrows + row;
+  for (uint32_t col = 0; col < dims[1]; col++) {
+    for (uint32_t row = 0; row < dims[0]; row++) {
+      ptrdiff_t idx = col * dims[0] + row;
       dem[idx] = 100.0f * pcg4d(row, col, seed, 0);
       fsm_excess[idx] = dem[idx];
       fmm_excess[idx] = dem[idx];
@@ -90,7 +88,7 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, ptrdiff_t nlayers,
       // Initialize lithstack with nlayers equally-spaced layers up to
       // 10 m greater than the maximum elevation.
       for (ptrdiff_t layer = 0; layer < nlayers; layer++) {
-        lithstack[(col * nrows + row) * nlayers + layer] =
+        lithstack[(col * dims[0] + row) * nlayers + layer] =
             110.0f * (layer + 1) / nlayers;
       }
     }
@@ -102,21 +100,21 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, ptrdiff_t nlayers,
     threshold_slopes3d[layer] = (layer % 2 == 0) ? 1.0f : 0.5f;
   }
 
-  excesstopography_fsm2d(fsm_excess, dem, threshold, cellsize, nrows, ncols);
+  excesstopography_fsm2d(fsm_excess, dem, threshold, cellsize, dims);
 
-  test_excess_constraint(fsm_excess, dem, nrows, ncols);
-  test_upwind_gradient(fsm_excess, threshold, cellsize, nrows, ncols);
+  test_excess_constraint(fsm_excess, dem, dims);
+  test_upwind_gradient(fsm_excess, threshold, cellsize, dims);
 
   excesstopography_fmm2d(fmm_excess, heap, back, dem, threshold, cellsize,
-                         nrows, ncols);
+                         dims);
 
-  test_excess_constraint(fmm_excess, dem, nrows, ncols);
-  test_upwind_gradient(fmm_excess, threshold, cellsize, nrows, ncols);
+  test_excess_constraint(fmm_excess, dem, dims);
+  test_upwind_gradient(fmm_excess, threshold, cellsize, dims);
 
   excesstopography_fmm3d(fmm_excess3d, heap3d, back3d, dem, lithstack,
-                         threshold_slopes3d, cellsize, nrows, ncols, nlayers);
+                         threshold_slopes3d, cellsize, dims, nlayers);
 
-  test_excess_constraint(fmm_excess3d, dem, nrows, ncols);
+  test_excess_constraint(fmm_excess3d, dem, dims);
 
   delete[] dem;
   delete[] fmm_excess;
@@ -141,30 +139,29 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, ptrdiff_t nlayers,
 // to taking the square root of negative numbers, so that the proposed
 // elevation is NaN. This proposal is never accepted, and the pixels
 // are left at their infinite values.
-int32_t eikonal_numerics_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t test) {
-  float *dem = new float[nrows * ncols];
-  float *excess = new float[nrows * ncols];
-  ptrdiff_t *heap = new ptrdiff_t[nrows * ncols];
-  ptrdiff_t *back = new ptrdiff_t[nrows * ncols];
-  float *threshold = new float[nrows * ncols];
+int32_t eikonal_numerics_test(ptrdiff_t dims[2], uint32_t test) {
+  float *dem = new float[dims[0] * dims[1]];
+  float *excess = new float[dims[0] * dims[1]];
+  ptrdiff_t *heap = new ptrdiff_t[dims[0] * dims[1]];
+  ptrdiff_t *back = new ptrdiff_t[dims[0] * dims[1]];
+  float *threshold = new float[dims[0] * dims[1]];
 
-  for (uint32_t j = 0; j < ncols; j++) {
-    for (uint32_t i = 0; i < nrows; i++) {
-      threshold[i + j * nrows] = pcg4d(i, j, test, 0);
-      if (i > 0 && i < nrows - 1 && j > 0 && j < ncols - 1) {
-        dem[i + j * nrows] = INFINITY;
+  for (uint32_t j = 0; j < dims[1]; j++) {
+    for (uint32_t i = 0; i < dims[0]; i++) {
+      threshold[i + j * dims[0]] = pcg4d(i, j, test, 0);
+      if (i > 0 && i < dims[0] - 1 && j > 0 && j < dims[1] - 1) {
+        dem[i + j * dims[0]] = INFINITY;
       } else {
-        dem[i + j * nrows] = 0.0f;
+        dem[i + j * dims[0]] = 0.0f;
       }
     }
   }
 
-  excesstopography_fmm2d(excess, heap, back, dem, threshold, 30.0, nrows,
-                         ncols);
+  excesstopography_fmm2d(excess, heap, back, dem, threshold, 30.0, dims);
 
-  test_upwind_gradient(excess, threshold, 30.0, nrows, ncols);
-  test_excess_constraint(excess, dem, nrows, ncols);
-  test_excess_isfinite(excess, nrows, ncols);
+  test_upwind_gradient(excess, threshold, 30.0, dims);
+  test_excess_constraint(excess, dem, dims);
+  test_excess_isfinite(excess, dims);
 
   delete[] dem;
   delete[] excess;
@@ -176,16 +173,15 @@ int32_t eikonal_numerics_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t test) {
 }
 
 int main(int argc, char *argv[]) {
-  ptrdiff_t nrows = 200;
-  ptrdiff_t ncols = 100;
+  ptrdiff_t dims[2] = {200, 100};
 
   for (uint32_t test = 0; test < 100; test++) {
-    int32_t result = random_dem_test(nrows, ncols, 8, test);
+    int32_t result = random_dem_test(dims, 8, test);
     if (result < 0) {
       return result;
     }
 
-    result = eikonal_numerics_test(nrows, ncols, test);
+    result = eikonal_numerics_test(dims, test);
     if (result < 0) {
       return result;
     }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -17,10 +17,10 @@ extern "C" {
   the corresponding pixel in the original DEM.
  */
 int32_t test_fillsinks_ge(float *original_dem, float *filled_dem,
-                          ptrdiff_t nrows, ptrdiff_t ncols) {
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      assert(filled_dem[i + nrows * j] >= original_dem[i + nrows * j]);
+                          ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      assert(filled_dem[i + dims[0] * j] >= original_dem[i + dims[0] * j]);
     }
   }
   return 0;
@@ -30,25 +30,24 @@ int32_t test_fillsinks_ge(float *original_dem, float *filled_dem,
   No pixel in the filled DEM should be completely surrounded by pixels higher
   than it.
  */
-int32_t test_fillsinks_filled(float *filled_dem, ptrdiff_t nrows,
-                              ptrdiff_t ncols) {
-  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
-  ptrdiff_t row_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
+int32_t test_fillsinks_filled(float *filled_dem, ptrdiff_t dims[2]) {
+  ptrdiff_t j_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
+  ptrdiff_t i_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
 
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      float z = filled_dem[i + nrows * j];
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float z = filled_dem[i + dims[0] * j];
       ptrdiff_t up_neighbor_count = 0;
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
-        ptrdiff_t neighbor_i = i + row_offset[neighbor];
-        ptrdiff_t neighbor_j = j + col_offset[neighbor];
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-        if (neighbor_i < 0 || neighbor_i >= nrows || neighbor_j < 0 ||
-            neighbor_j >= ncols) {
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
           continue;
         }
 
-        if (filled_dem[neighbor_i + nrows * neighbor_j] > z) {
+        if (filled_dem[neighbor_i + dims[0] * neighbor_j] > z) {
           up_neighbor_count++;
         }
       }
@@ -63,15 +62,15 @@ int32_t test_fillsinks_filled(float *filled_dem, ptrdiff_t nrows,
   8 higher neighbors should be labeled a flat. Likewise, every flat
   should have no lower neighbors and fewer than 8 higher neighbors.
  */
-int32_t test_identifyflats_flats(int32_t *flats, float *dem, ptrdiff_t nrows,
-                                 ptrdiff_t ncols) {
+int32_t test_identifyflats_flats(int32_t *flats, float *dem,
+                                 ptrdiff_t dims[2]) {
   ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
   ptrdiff_t row_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
 
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      float z = dem[i + nrows * j];
-      int32_t flat = flats[i + nrows * j];
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float z = dem[i + dims[0] * j];
+      int32_t flat = flats[i + dims[0] * j];
 
       int32_t up_neighbor_count = 0;
       int32_t down_neighbor_count = 0;
@@ -79,12 +78,12 @@ int32_t test_identifyflats_flats(int32_t *flats, float *dem, ptrdiff_t nrows,
         ptrdiff_t neighbor_i = i + row_offset[neighbor];
         ptrdiff_t neighbor_j = j + col_offset[neighbor];
 
-        if (neighbor_i < 0 || neighbor_i >= nrows || neighbor_j < 0 ||
-            neighbor_j >= ncols) {
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
           continue;
         }
 
-        float neighbor_height = dem[neighbor_i + nrows * neighbor_j];
+        float neighbor_height = dem[neighbor_i + dims[0] * neighbor_j];
 
         if (neighbor_height > z) {
           up_neighbor_count++;
@@ -93,7 +92,7 @@ int32_t test_identifyflats_flats(int32_t *flats, float *dem, ptrdiff_t nrows,
         }
       }
       int32_t current_pixel_on_boundary =
-          i == 0 || i == nrows - 1 || j == 0 || j == ncols - 1;
+          i == 0 || i == dims[0] - 1 || j == 0 || j == dims[1] - 1;
 
       assert((!current_pixel_on_boundary && (down_neighbor_count == 0) &&
               (up_neighbor_count < 8)) == ((flat & 1) == 1));
@@ -107,33 +106,33 @@ int32_t test_identifyflats_flats(int32_t *flats, float *dem, ptrdiff_t nrows,
   Every pixel that has a lower neighbor, borders a flat, and has the
   same elevation as a flat that it touches should be labeled a sill.
 */
-int32_t test_identifyflats_sills(int32_t *flats, float *dem, ptrdiff_t nrows,
-                                 ptrdiff_t ncols) {
-  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
-  ptrdiff_t row_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
+int32_t test_identifyflats_sills(int32_t *flats, float *dem,
+                                 ptrdiff_t dims[2]) {
+  ptrdiff_t j_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
+  ptrdiff_t i_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
 
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      float z = dem[i + j * nrows];
-      int32_t flat = flats[i + j * nrows];
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float z = dem[i + j * dims[0]];
+      int32_t flat = flats[i + j * dims[0]];
 
       int32_t down_neighbor_count = 0;
       int32_t equal_neighbor_flats = 0;
 
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
-        ptrdiff_t neighbor_i = i + row_offset[neighbor];
-        ptrdiff_t neighbor_j = j + col_offset[neighbor];
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-        if (neighbor_i < 0 || neighbor_i >= nrows || neighbor_j < 0 ||
-            neighbor_j >= ncols) {
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
           // Count boundary pixels as down neighbors so sills can
           // drain off the map.
           down_neighbor_count++;
           continue;
         }
 
-        float neighbor_height = dem[neighbor_i + nrows * neighbor_j];
-        int32_t neighbor_flat = flats[neighbor_i + nrows * neighbor_j];
+        float neighbor_height = dem[neighbor_i + dims[0] * neighbor_j];
+        int32_t neighbor_flat = flats[neighbor_i + dims[0] * neighbor_j];
 
         if (neighbor_height < z) {
           down_neighbor_count++;
@@ -155,29 +154,29 @@ int32_t test_identifyflats_sills(int32_t *flats, float *dem, ptrdiff_t nrows,
   Every pixel that is a flat and borders a sill of the same
   height should be labeled a presill
 */
-int32_t test_identifyflats_presills(int32_t *flats, float *dem, ptrdiff_t nrows,
-                                    ptrdiff_t ncols) {
-  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
-  ptrdiff_t row_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
+int32_t test_identifyflats_presills(int32_t *flats, float *dem,
+                                    ptrdiff_t dims[2]) {
+  ptrdiff_t j_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
+  ptrdiff_t i_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
 
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      float z = dem[i + j * nrows];
-      int32_t flat = flats[i + j * nrows];
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float z = dem[i + j * dims[0]];
+      int32_t flat = flats[i + j * dims[0]];
 
       int32_t equal_neighbor_sills = 0;
 
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
-        ptrdiff_t neighbor_i = i + row_offset[neighbor];
-        ptrdiff_t neighbor_j = j + col_offset[neighbor];
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-        if (neighbor_i < 0 || neighbor_i >= nrows || neighbor_j < 0 ||
-            neighbor_j >= ncols) {
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
           continue;
         }
 
-        float neighbor_height = dem[neighbor_i + nrows * neighbor_j];
-        int32_t neighbor_flat = flats[neighbor_i + nrows * neighbor_j];
+        float neighbor_height = dem[neighbor_i + dims[0] * neighbor_j];
+        int32_t neighbor_flat = flats[neighbor_i + dims[0] * neighbor_j];
 
         if (((neighbor_flat & 2) > 0) && (neighbor_height == z)) {
           equal_neighbor_sills++;
@@ -194,12 +193,11 @@ int32_t test_identifyflats_presills(int32_t *flats, float *dem, ptrdiff_t nrows,
 /*
   Costs should be zero on nonflats and positive on flats.
  */
-int32_t test_gwdt_costs(float *costs, int32_t *flats, ptrdiff_t nrows,
-                        ptrdiff_t ncols) {
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      float cost = costs[i + nrows * j];
-      int32_t flat = flats[i + nrows * j];
+int32_t test_gwdt_costs(float *costs, int32_t *flats, ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float cost = costs[i + dims[0] * j];
+      int32_t flat = flats[i + dims[0] * j];
 
       assert((cost >= 0) && (((flat & 1) > 0) == (cost > 0)));
     }
@@ -213,30 +211,30 @@ int32_t test_gwdt_costs(float *costs, int32_t *flats, ptrdiff_t nrows,
   connected component label
  */
 int32_t test_gwdt_conncomps(ptrdiff_t *conncomps, int32_t *flats,
-                            ptrdiff_t nrows, ptrdiff_t ncols) {
-  ptrdiff_t col_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
-  ptrdiff_t row_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
+                            ptrdiff_t dims[2]) {
+  ptrdiff_t j_offset[8] = {-1, -1, -1, 0, 1, 1, 1, 0};
+  ptrdiff_t i_offset[8] = {1, 0, -1, -1, -1, 0, 1, 1};
 
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      ptrdiff_t label = conncomps[i + nrows * j];
-      int32_t flat = flats[i + nrows * j];
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t label = conncomps[i + dims[0] * j];
+      int32_t flat = flats[i + dims[0] * j];
 
       if (!(flat & 1)) {
         continue;
       }
 
       for (int32_t neighbor = 0; neighbor < 8; neighbor++) {
-        ptrdiff_t neighbor_i = i + row_offset[neighbor];
-        ptrdiff_t neighbor_j = j + col_offset[neighbor];
+        ptrdiff_t neighbor_i = i + i_offset[neighbor];
+        ptrdiff_t neighbor_j = j + j_offset[neighbor];
 
-        if (neighbor_i < 0 || neighbor_i >= nrows || neighbor_j < 0 ||
-            neighbor_j >= ncols) {
+        if (neighbor_i < 0 || neighbor_i >= dims[0] || neighbor_j < 0 ||
+            neighbor_j >= dims[1]) {
           continue;
         }
 
-        int32_t neighbor_flat = flats[neighbor_i + nrows * neighbor_j];
-        ptrdiff_t neighbor_label = conncomps[neighbor_i + nrows * neighbor_j];
+        int32_t neighbor_flat = flats[neighbor_i + dims[0] * neighbor_j];
+        ptrdiff_t neighbor_label = conncomps[neighbor_i + dims[0] * neighbor_j];
         if (neighbor_flat & 1) {
           assert(neighbor_label == label);
         }
@@ -256,11 +254,11 @@ int32_t test_gwdt_conncomps(ptrdiff_t *conncomps, int32_t *flats,
   between the parent and the current pixel.
  */
 int32_t test_gwdt(float *dist, ptrdiff_t *prev, float *costs, int32_t *flats,
-                  ptrdiff_t nrows, ptrdiff_t ncols) {
-  for (ptrdiff_t j = 0; j < ncols; j++) {
-    for (ptrdiff_t i = 0; i < nrows; i++) {
-      float d = dist[i + j * nrows];
-      int32_t flat = flats[i + j * nrows];
+                  ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float d = dist[i + j * dims[0]];
+      int32_t flat = flats[i + j * dims[0]];
 
       assert(d >= 0);
 
@@ -269,12 +267,13 @@ int32_t test_gwdt(float *dist, ptrdiff_t *prev, float *costs, int32_t *flats,
       } else if (flat & 1) {
         assert(d > 1.0);
 
-        ptrdiff_t parent = prev[i + j * nrows];
-        ptrdiff_t parent_j = parent / nrows;
-        ptrdiff_t parent_i = parent % nrows;
+        ptrdiff_t parent = prev[i + j * dims[0]];
+        ptrdiff_t parent_j = parent / dims[0];
+        ptrdiff_t parent_i = parent % dims[0];
         float chamfer = (parent_j != j) && (parent_i != i) ? SQRT2f : 1.0f;
         float proposed_dist =
-            dist[parent] + chamfer * (costs[i + j * nrows] + costs[parent]) / 2;
+            dist[parent] +
+            chamfer * (costs[i + j * dims[0]] + costs[parent]) / 2;
         assert(proposed_dist == d);
       }
     }
@@ -283,53 +282,53 @@ int32_t test_gwdt(float *dist, ptrdiff_t *prev, float *costs, int32_t *flats,
   return 0;
 }
 
-int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
+int32_t random_dem_test(ptrdiff_t dims[2], uint32_t seed) {
   // Allocate variables
 
   // Input DEM
-  float *dem = new float[nrows * ncols];
+  float *dem = new float[dims[0] * dims[1]];
 
   // Output for fillsinks
-  float *filled_dem = new float[nrows * ncols];
+  float *filled_dem = new float[dims[0] * dims[1]];
 
   // Output for identifyflats
-  int32_t *flats = new int32_t[nrows * ncols];
+  int32_t *flats = new int32_t[dims[0] * dims[1]];
 
   // Outputs for compute_costs
-  ptrdiff_t *conncomps = new ptrdiff_t[nrows * ncols];
-  float *costs = new float[nrows * ncols];
+  ptrdiff_t *conncomps = new ptrdiff_t[dims[0] * dims[1]];
+  float *costs = new float[dims[0] * dims[1]];
 
   // Outputs and intermediate needs for gwdt
-  float *dist = new float[nrows * ncols];
-  ptrdiff_t *heap = new ptrdiff_t[nrows * ncols];
-  ptrdiff_t *back = new ptrdiff_t[nrows * ncols];
-  ptrdiff_t *prev = new ptrdiff_t[nrows * ncols];
+  float *dist = new float[dims[0] * dims[1]];
+  ptrdiff_t *heap = new ptrdiff_t[dims[0] * dims[1]];
+  ptrdiff_t *back = new ptrdiff_t[dims[0] * dims[1]];
+  ptrdiff_t *prev = new ptrdiff_t[dims[0] * dims[1]];
 
-  for (uint32_t col = 0; col < ncols; col++) {
-    for (uint32_t row = 0; row < nrows; row++) {
-      dem[col * nrows + row] = 100.0f * pcg4d(row, col, seed, 1);
+  for (uint32_t col = 0; col < dims[1]; col++) {
+    for (uint32_t row = 0; row < dims[0]; row++) {
+      dem[col * dims[0] + row] = 100.0f * pcg4d(row, col, seed, 1);
     }
   }
 
   // Run flow routing algorithms
-  fillsinks(filled_dem, dem, nrows, ncols);
+  fillsinks(filled_dem, dem, dims);
 
-  test_fillsinks_ge(dem, filled_dem, nrows, ncols);
-  test_fillsinks_filled(filled_dem, nrows, ncols);
+  test_fillsinks_ge(dem, filled_dem, dims);
+  test_fillsinks_filled(filled_dem, dims);
 
-  identifyflats(flats, filled_dem, nrows, ncols);
+  identifyflats(flats, filled_dem, dims);
 
-  test_identifyflats_flats(flats, filled_dem, nrows, ncols);
-  test_identifyflats_sills(flats, filled_dem, nrows, ncols);
-  test_identifyflats_presills(flats, filled_dem, nrows, ncols);
+  test_identifyflats_flats(flats, filled_dem, dims);
+  test_identifyflats_sills(flats, filled_dem, dims);
+  test_identifyflats_presills(flats, filled_dem, dims);
 
-  gwdt_computecosts(costs, conncomps, flats, dem, filled_dem, nrows, ncols);
+  gwdt_computecosts(costs, conncomps, flats, dem, filled_dem, dims);
 
-  test_gwdt_costs(costs, flats, nrows, ncols);
-  test_gwdt_conncomps(conncomps, flats, nrows, ncols);
+  test_gwdt_costs(costs, flats, dims);
+  test_gwdt_conncomps(conncomps, flats, dims);
 
-  gwdt(dist, prev, costs, flats, heap, back, nrows, ncols);
-  test_gwdt(dist, prev, costs, flats, nrows, ncols);
+  gwdt(dist, prev, costs, flats, heap, back, dims);
+  test_gwdt(dist, prev, costs, flats, dims);
 
   delete[] dem;
   delete[] filled_dem;
@@ -345,11 +344,10 @@ int32_t random_dem_test(ptrdiff_t nrows, ptrdiff_t ncols, uint32_t seed) {
 }
 
 int main(int argc, char *argv[]) {
-  ptrdiff_t nrows = 100;
-  ptrdiff_t ncols = 200;
+  ptrdiff_t dims[2] = {100, 200};
 
   for (uint32_t test = 0; test < 100; test++) {
-    int32_t result = random_dem_test(nrows, ncols, test);
+    int32_t result = random_dem_test(dims, test);
     if (result < 0) {
       return result;
     }


### PR DESCRIPTION
This PR renames the `nrows` and `ncols` arguments of every libtopotoolbox function to a single `dims[2]` argument. As discussed elsewhere (#23 #68), this is an ergonomic change rather than a functional one. It only prevents the awkward situation of having to pass the number of columns to an argument named `nrows` when using a row-major array.

This is a breaking change. Packages that use libtopotoolbox now must create and pass a two-element array containing the dimensions. Column-major arrays should use `ptrdiff_t dims[2] = {nrows, ncols};`, while row-major arrays should use `ptrdiff_t dims[2] = {ncols,nrows};`

Partially addresses #23