### PR TITLE
Improve CMake configuration time on Windows in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |          
           echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
-          echo "CMAKE_CONFIGURATION_TYPES=\"Release\"" >> "$env:GITHUB_ENV"
+          echo "CMAKE_CONFIGURATION_TYPES=Release" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,10 @@ jobs:
             c_compiler: cl
     steps:
       - uses: actions/checkout@v4
+      - name: Set environment variables on Windows
+        if: matrix.os == "windows-latest"
+        run:
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static
@@ -68,7 +72,6 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
           -DBUILD_SHARED_LIBS=OFF
-          -DCMAKE_CONFIGURATION_TYPES="Release"
           --profiling-format=google-trace
           --profiling-output ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
       - name: Build static library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,8 +68,8 @@ jobs:
         if: matrix.os == 'windows-latest'
       - name: Set environment variables on Windows
         if: matrix.os == 'windows-latest'
-        run:
-          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV"
+        run: |          
+          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
           echo "CMAKE_CONFIGURATION_TYPES=\"Release\"" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,5 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: cmake_profiles
+          name: ${{matrix.os}}_${{matrix.c_compiler}}_cmake_profiles
           path: ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
-          
-        

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
           -DBUILD_SHARED_LIBS=OFF
+          -DCMAKE_CONFIGURATION_TYPES="Release"
           --profiling-format=google-trace
           --profiling-output ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
       - name: Build static library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set environment variables on Windows
-        if: matrix.os == "windows-latest"
+        if: matrix.os == windows-latest
         run:
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
       - name: Configure static library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,9 @@ jobs:
             c_compiler: cl
     steps:
       - uses: actions/checkout@v4
+      - name: Install ninja on windows
+        uses: seanmiddleditch/gha-setup-ninja@master
+        if: matrix.os == 'windows-latest'
       - name: Set environment variables on Windows
         if: matrix.os == 'windows-latest'
         run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Set environment variables on Windows
         if: matrix.os == 'windows-latest'
         run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
           echo "CMAKE_CONFIGURATION_TYPES=Release" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: ["main"]
   push:
-    branches: ["main","windows-compile-time"]
+    branches: ["main"]
 
 jobs:
   format-check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: ["main"]
   push:
-    branches: ["main"]
+    branches: ["main","windows-compile-time"]
 
 jobs:
   format-check:
@@ -68,6 +68,8 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.cpp_compiler}}
           -DTT_BUILD_TESTS=ON
           -DBUILD_SHARED_LIBS=OFF
+          --profiling-format=google-trace
+          --profiling-output ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
       - name: Build static library
         run: cmake --build ${{github.workspace}}/build/static --config Release
       - name: Test static library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,13 @@ jobs:
             c_compiler: cl
     steps:
       - uses: actions/checkout@v4
+      - name: Install ninja on windows
+        uses: seanmiddleditch/gha-setup-ninja@master
+        if: matrix.os == 'windows-latest'
+      - name: Set environment variables on Windows
+        if: matrix.os == 'windows-latest'
+        run:
+          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set environment variables on Windows
-        if: matrix.os == windows-latest
+        if: matrix.os == 'windows-latest'
         run:
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
       - name: Configure static library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run:
           echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV"
+          echo "CMAKE_CONFIGURATION_TYPES=\"Release\"" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,8 +68,7 @@ jobs:
         if: matrix.os == 'windows-latest'
       - name: Set environment variables on Windows
         if: matrix.os == 'windows-latest'
-        run: |          
-          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
+        run: |
           echo "CMAKE_CONFIGURATION_TYPES=Release" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Set environment variables on Windows
         if: matrix.os == 'windows-latest'
         run:
-          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Install ninja on windows
         uses: seanmiddleditch/gha-setup-ninja@master
         if: matrix.os == 'windows-latest'
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
       - name: Set environment variables on Windows
         if: matrix.os == 'windows-latest'
         run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,13 +60,6 @@ jobs:
             c_compiler: cl
     steps:
       - uses: actions/checkout@v4
-      - name: Install ninja on windows
-        uses: seanmiddleditch/gha-setup-ninja@master
-        if: matrix.os == 'windows-latest'
-      - name: Set environment variables on Windows
-        if: matrix.os == 'windows-latest'
-        run:
-          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV"
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,3 +85,10 @@ jobs:
           -DTT_SANITIZE=OFF
       - name: Build shared library
         run: cmake --build ${{github.workspace}}/build/shared --config Release
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake_profiles
+          path: ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
+          
+        


### PR DESCRIPTION
Resolves #71

This PR should reduce the amount of time CI spends configuring the CMake build system on Windows by 

1. Switching to the Ninja generator rather than using Visual Studio
2. Removing extra configuration types.

It is still a bit slower than the Linux and macos builds, but not 4 times as slow.
