### PR TITLE
Implement hybrid morphological reconstruction for fillsinks

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -51,6 +51,32 @@ TOPOTOOLBOX_API
 void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
 
 /**
+   @brief Fills sinks in a digital elevation model
+
+   Uses an algorithm based on grayscale morphological
+   reconstruction. Uses the hybrid algorithm of Vincent (1993) for
+   higher performance than fillsinks(), but requires additional memory
+   allocation for a FIFO queue.
+
+   # References
+
+   Vincent, Luc. (1993). Morphological grayscale reconstruction in
+   image analysis: applications and efficient algorithms. IEEE
+   Transactions on Image Processing, Vol. 2, No. 2.
+   https://doi.org/10.1109/83.217222
+
+   @param[out] output The filled DEM
+   @param[out] queue  An array of `ptrdiff_t` the same size as the DEMs used as
+                      the backing store for the queue
+   @param[in]  dem    The input DEM
+   @param[in]  dims   The dimensions of both DEMs with the fastest changing
+                      dimension first
+ */
+TOPOTOOLBOX_API
+void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem,
+                      ptrdiff_t dims[2]);
+
+/**
    @brief Labels flat, sill and presill pixels in the provided DEM
 
    A flat pixel is one surrounded by pixels with the same or higher

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -47,3 +47,32 @@ void fillsinks(float *output, float *dem, ptrdiff_t dims[2]) {
     }
   }
 }
+
+TOPOTOOLBOX_API
+void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem,
+                      ptrdiff_t dims[2]) {
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      // Invert the DEM
+      dem[j * dims[0] + i] *= -1.0;
+
+      // Set the boundary pixels of the output equal to the DEM and
+      // the interior pixels equal to -INFINITY.
+      if ((i == 0 || i == (dims[0] - 1)) || (j == 0 || j == (dims[1] - 1))) {
+        output[j * dims[0] + i] = dem[j * dims[0] + i];
+      } else {
+        output[j * dims[0] + i] = -INFINITY;
+      }
+    }
+  }
+
+  reconstruct_hybrid(output, queue, dem, dims);
+
+  // Revert the DEM and the output
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      dem[j * dims[0] + i] *= -1.0;
+      output[j * dims[0] + i] *= -1.0;
+    }
+  }
+}

--- a/src/morphology/reconstruct.h
+++ b/src/morphology/reconstruct.h
@@ -4,5 +4,7 @@
 #include <stddef.h>
 
 void reconstruct(float *marker, float *mask, ptrdiff_t dims[2]);
+void reconstruct_hybrid(float *marker, ptrdiff_t *queue, float *mask,
+                        ptrdiff_t dims[2]);
 
 #endif  // TOPOTOOLBOX_MORPHOLOGY_RECONSTRUCT_H

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -392,6 +392,9 @@ int32_t random_dem_test(ptrdiff_t dims[2], uint32_t seed) {
   float *filled_dem = new float[dims[0] * dims[1]];
   assert(filled_dem != NULL);
 
+  ptrdiff_t *queue = new ptrdiff_t[dims[0] * dims[1]];
+  assert(queue != NULL);
+
   // Output for identifyflats
   int32_t *flats = new int32_t[dims[0] * dims[1]];
   assert(flats != NULL);
@@ -432,7 +435,14 @@ int32_t random_dem_test(ptrdiff_t dims[2], uint32_t seed) {
   }
 
   // Run flow routing algorithms
-  fillsinks(filled_dem, dem, dims);
+
+  // Alternate between the hybrid and the sequential fillsinks
+  // algorithms.
+  if (seed & 1) {
+    fillsinks_hybrid(filled_dem, queue, dem, dims);
+  } else {
+    fillsinks(filled_dem, dem, dims);
+  }
 
   test_fillsinks_ge(dem, filled_dem, dims);
   test_fillsinks_filled(filled_dem, dims);
@@ -460,6 +470,7 @@ int32_t random_dem_test(ptrdiff_t dims[2], uint32_t seed) {
 
   delete[] dem;
   delete[] filled_dem;
+  delete[] queue;
   delete[] flats;
   delete[] conncomps;
   delete[] costs;


### PR DESCRIPTION
Resolves #74

include/topotoolbox.h now has a new `fillsinks_hybrid` API declaration as well as documentation for this function.

src/fillsinks.c defines `fillsinks_hybrid`, which is identical to `fillsinks`, except that it calls `reconstruct_hybrid`.

src/morphology/reconstruct.h adds the `reconstruct_hybrid` declaration.

src/morphology/reconstruct.c implements `reconstruct_hybrid` by adding

1. A FIFO queue implementation called `PixelQueue`
2. A modified `backward_scan` that fills a PixelQueue if provided.
3. The `propagate` step, which updates the image through a breadth-first search.

test/random_dem.cpp now alternates between testing the `fillsinks` and `fillsinks_hybrid` implementations.