### PR TITLE
Add links to the GitHub repository to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,8 @@ html_static_path = ['_static']
 html_logo = 'logo.png'
 
 html_theme_options = {
+    "repository_url": "https://github.com/TopoToolbox/libtopotoolbox",
+    "use_repository_button": True,
 }
 
 # Breathe configuration

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,8 @@ libtopotoolbox
 
 libtopotoolbox is a C library for the analysis of digital elevation models that powers `TopoToolbox v3 <https://topotoolbox.github.io>`_. It provides implementations of fundamental algorithms for terrain analysis.
 
+libtopotoolbox is open source code released under the GPL v3 license. The source repository can be found on `GitHub <https://github.com/TopoToolbox/libtopotoolbox>`_.
+
 If you are primarily interested in using TopoToolbox for your work, studies or research, you may find the `main TopoToolbox documentation <https://topotoolbox.github.io>`_ useful.
 
 A tutorial on :doc:`tutorials/fillsinks/tutorial` shows how to incorporate libtopotoolbox into your own project.


### PR DESCRIPTION
This adds a GitHub icon to the header that links to the repository as well as some text including a link to the repository from the landing page.