### PR TITLE
Implement flow_routing_targets

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -400,6 +400,25 @@ void flow_routing_d8_carve(ptrdiff_t *source, uint8_t *direction, float *dem,
                            float *dist, int32_t *flats, ptrdiff_t dims[2]);
 
 /**
+   @brief Compute downstream pixel indices from flow directions
+
+   The `source` and `direction` outputs from flow_routing_d8()
+   implicitly define the downstream targets of each edge in the flow
+   network. This function computes the linear indices of those
+   downstream targets and stores them in the `target` array.
+
+   @param[out]  target     The target pixel for each edge.
+   @param[in]   source     The source pixel for each edge.
+   @param[in]   direction  The flow directions as a bit field encoded as in
+                           flow_routing_d8_carve();
+   @param[in]   dims       The dimensions of the arrays with the fastest
+                           changing dimension first.
+ */
+TOPOTOOLBOX_API
+void flow_routing_targets(ptrdiff_t *target, ptrdiff_t *source,
+                          uint8_t *direction, ptrdiff_t dims[2]);
+
+/**
    @brief Compute flow accumulation
 
    Accumulates flow by summing contributing areas along flow paths. Uses the

--- a/src/flow_routing.c
+++ b/src/flow_routing.c
@@ -215,3 +215,26 @@ void flow_routing_d8_carve(ptrdiff_t *source, uint8_t *direction, float *dem,
     }
   }
 }
+
+TOPOTOOLBOX_API
+void flow_routing_targets(ptrdiff_t *target, ptrdiff_t *source,
+                          uint8_t *direction, ptrdiff_t dims[2]) {
+  ptrdiff_t offsets[8] = {dims[0],  dims[0] + 1,  1,  -dims[0] + 1,
+                          -dims[0], -dims[0] - 1, -1, dims[0] - 1};
+
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t node = source[j * dims[0] + i];
+
+      uint8_t flowdir = direction[node];
+
+      uint8_t v = flowdir;
+      uint8_t r = 0;
+      while (v >>= 1) {
+        r++;
+      }
+
+      target[j * dims[0] + i] = node + offsets[r];
+    }
+  }
+}


### PR DESCRIPTION
Closes #84

This function converts the source pixels and the flow directions to target pixels for each edge.

include/topotoolbox.h adds flow_routing_targets to the API and documents the function.

src/flow_routing.c implements flow_routing_targets.

test/random_dem.cpp adds a test that compares the offset implied by the flow direction to the offset between source and target.