### PR TITLE
Add flow_routing_targets to API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,4 +17,6 @@ API Documentation
 
 .. doxygenfunction:: flow_routing_d8_carve
 
+.. doxygenfunction:: flow_routing_targets
+
 .. doxygenfunction:: flow_accumulation


### PR DESCRIPTION
I forgot to add the new function to `docs/api.rst` in #85. 

It would be nice if we could generate `docs/api.rst` automatically from functions with the `TOPOTOOLBOX_API` qualifier.