### PR TITLE
Use doxygenfile directive to automatically generate API listing

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,22 +1,5 @@
 API Documentation
 =================
 
-.. doxygenfunction:: fillsinks
-		     
-.. doxygenfunction:: identifyflats
-
-.. doxygenfunction:: gwdt_computecosts
-
-.. doxygenfunction:: gwdt
-
-.. doxygenfunction:: excesstopography_fsm2d
-
-.. doxygenfunction:: excesstopography_fmm2d
-
-.. doxygenfunction:: excesstopography_fmm3d
-
-.. doxygenfunction:: flow_routing_d8_carve
-
-.. doxygenfunction:: flow_routing_targets
-
-.. doxygenfunction:: flow_accumulation
+.. doxygenfile:: topotoolbox.h
+   :sections: func


### PR DESCRIPTION
Closes #88

The doxygenfile direction outputs an entry for everything Doxygen documents in the given file. Since the public API is defined in include/topotoolbox.h, this will work.

The :sections: func option displays only functions, to prevent displaying the unhelpful TOPOTOOLBOX_VERSION_* defines. This may need to be changed in the future if additional declarations (i.e. structs, other defines) need to be documented.