### PR TITLE
Add inline documentation of the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,14 @@ project(
   LANGUAGES C CXX
 )
 
+# libtopotoolbox/cmake contains additional CMake modules necessary for
+# our build process.
+#
+# If you need build system functionality that is not built into CMake, add
+# the relevant CMake module to this directory.
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+# Language standards and compiler settings
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -16,13 +22,15 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+# TopoToolbox specific build options
+#
+# These should start with the prefix `TT_`
 OPTION(TT_BUILD_TESTS "Build libtopotoolbox tests" OFF)
 OPTION(TT_BUILD_DOCS "Build libtopotoolbox documentation" OFF)
 OPTION(TT_INSTALL "Install libtopotoolbox" OFF)
 
-include(CTest)
-include(GNUInstallDirs)
 
+# Compiler warnings
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 if (MSVC)
   add_compile_options(/W4 /wd4100)
@@ -30,20 +38,37 @@ else()
   add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
+# Library source code is in the src/ directory
+# See src/CMakeLists.txt for the library configuration
 add_subdirectory(src)
+
+# Tests are in the test/ directory
+# See test/CMakeLists.txt for the test configuration
+include(CTest)
 
 if (TT_BUILD_TESTS)
   add_subdirectory(test)
 endif()
 
+# Documentation is built from the docs/ directory
+# See docs/CMakeLists.txt for the documentation configuration
 if (TT_BUILD_DOCS)
   add_subdirectory(docs)
 endif()
+
+# Set up the install targets
+include(GNUInstallDirs)
 
 if (TT_INSTALL)
   # Only set up the install targets if TT_INSTALL is set
   
   # CMake package configuration
+  #
+  # Generate TopoToolboxConfig.cmake, which find_package()
+  # uses to locate an installed version of libtopotoolbox.
+  #
+  # This file will be installed in something like
+  # $PREFIX/lib/cmake/topotoolbox, depending on the OS.
   include(CMakePackageConfigHelpers)
   configure_package_config_file(
     cmake/TopoToolboxConfig.cmake.in
@@ -52,13 +77,15 @@ if (TT_INSTALL)
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   )
 
+  # Generate the TopoToolboxConfigVersion.cmake, which find_package()
+  # uses to ensure that the requested version is installed.
   write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
   )
 
-  # Install library
+  # Install the compiled library and header file
   install(TARGETS topotoolbox EXPORT topotoolbox-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
@@ -69,6 +96,8 @@ if (TT_INSTALL)
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   )
 
+  # Install the CMake package configuration files in the appropriate
+  # location
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/TopoToolboxConfigVersion.cmake

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,15 +1,30 @@
+# Build the documentation using Doxygen and Sphinx
+#
+# This CMake file is largely derived from Sy Brand's 2019 article
+# "Clear, Functional C++ Documentation with Sphinx + Breathe + Doxygen + CMake"
+# on the Microsoft C++ Team Blog:
+# https://web.archive.org/web/20240608084430/https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/
+
+# Set up Doxygen
 find_package(Doxygen REQUIRED)
 
+# Doxygen-specific variables
 set(DOXYGEN_INPUT_DIR "${PROJECT_SOURCE_DIR}/include")
 set(DOXYGEN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/docs/doxygen")
 set(DOXYGEN_INDEX_FILE "${DOXYGEN_OUTPUT_DIR}/html/index.html")
 set(DOXYFILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in")
 set(DOXYFILE_OUT "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
 
+# Doxyfile.in is a template that is filled out and turned into the
+# Doxyfile by configure_file
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
 file(MAKE_DIRECTORY ${DOXYGEN_OUTPUT_DIR})
 
+# Run Doxygen
+#
+# This will be run automatically because the Sphinx configuration
+# below depends on the ${DOXYGEN_INDEX_FILE}
 add_custom_command(
   OUTPUT ${DOXYGEN_INDEX_FILE}
   DEPENDS topotoolbox
@@ -23,11 +38,20 @@ add_custom_command(
 
 find_package(Sphinx REQUIRED)
 
+# Sphinx-specific variables
 set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
 set(SPHINX_BUILD "${CMAKE_CURRENT_BINARY_DIR}/docs/sphinx")
 set(SPHINX_INDEX_FILE "${SPHINX_BUILD}/index.html")
+
+# Find all of the reStructuredText files in the docs/ directory and
+# its subdirectories. This is used to define the dependencies so that
+# CMake knows when Sphinx needs to be rerun. This is only for the
+# build system: Sphinx finds documentation source files itself.
 file(GLOB_RECURSE TOPOTOOLBOX_DOCS_RST ${CMAKE_CURRENT_SOURCE_DIR}/*.rst)
 
+# Run Sphinx
+# 
+# The Sphinx configuration is in conf.py
 add_custom_command(
   OUTPUT ${SPHINX_INDEX_FILE}
   COMMAND
@@ -40,5 +64,7 @@ add_custom_command(
   COMMENT "Generating documentation with Sphinx"
 )
 
+# The docs target can be built explicitly with
+# cmake --build build --target docs
 add_custom_target(docs ALL DEPENDS ${SPHINX_INDEX_FILE})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Library declaration
+#
+# Every file that needs to be compiled should be listed here.
 add_library(topotoolbox
   topotoolbox.c
   fillsinks.c
@@ -15,6 +18,12 @@ add_library(topotoolbox
   flow_accumulation.c
 )
 
+# Define the include directory
+#
+# When we are building the library, look in include/
+#
+# When we install the library, look in the appropriate system include
+# directory
 target_include_directories(
   topotoolbox
   PUBLIC
@@ -22,14 +31,27 @@ target_include_directories(
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
 )
 
+# Link libm if necessary
+#
+# Not every platform has a separate libm that needs to be linked, this
+# conditional ensures that we only try to link libm if it exists separately
 find_library(MATH_LIBRARY m)
 if(MATH_LIBRARY)
     target_link_libraries(topotoolbox PUBLIC ${MATH_LIBRARY})
 endif()
 
+# Set TOPOTOOLBOX_STATICLIB if we are *not* building a shared library
+#
+# TOPOTOOLBOX_STATICLIB is a macro defined in include/topotoolbox.h
+# that determines the appropriate TOPOTOOLBOX_API qualifier when
+# libtopotoolbox is built as a static library.
 if (BUILD_SHARED_LIBS)
 else()
   target_compile_options(topotoolbox PUBLIC -DTOPOTOOLBOX_STATICLIB)
 endif()
 
+# Define include/topotoolbox.h as a PUBLIC_HEADER
+#
+# This is used in the root CMakeLists.txt to install topotoolbox.h to
+# the appropriate location.
 set_target_properties(topotoolbox PROPERTIES PUBLIC_HEADER ${topotoolbox_SOURCE_DIR}/include/topotoolbox.h)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,39 @@
+# Set TT_SANITIZE=ON to build the tests with AddressSanitizer
+#
+# We run the tests with AddressSanitizer on CI to catch certain memory
+# access errors, but AddressSanitizer adds significant overhead to
+# programs, so it is not enabled by default.
 OPTION(TT_SANITIZE "Build with AddressSanitizer" OFF)
 
+# Test declarations should generally follow the pattern below, which
+# is described in more detail for the versioninfo test
+
+# TEST: versioninfo
+#
+# This test prints out the defined version numbers. It is mainly used
+# to ensure that everything is linked properly.
+
+# add_executable defines the executable program that CTest will
+# run. Include any necessary files that must be compiled in this command.
 add_executable(versioninfo versioninfo.cpp utils.c)
+
+# Link the executable to topotoolbox.
 target_link_libraries(versioninfo PRIVATE topotoolbox)
+
+# Add the executable to CTest so that it will run it.
 add_test(NAME versioninfo COMMAND versioninfo)
+
+# This property is required on Windows to ensure that the shared
+# library is found when running the test.
 set_tests_properties(versioninfo PROPERTIES ENVIRONMENT_MODIFICATION
 "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 
+# TEST: random_dem
+#
+# Runs libtopotoolbox functions on randomly generated DEMs
 add_executable(random_dem random_dem.cpp utils.c)
 if (TT_SANITIZE AND NOT MSVC)
+  # Set up the AddressSanitizer flags
   target_compile_options(random_dem PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
   target_link_options(random_dem PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
 endif()
@@ -16,8 +42,12 @@ add_test(NAME random_dem COMMAND random_dem)
 set_tests_properties(random_dem PROPERTIES ENVIRONMENT_MODIFICATION
   "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 
+# TEST: excesstopography
+#
+# Runs the excesstopography functions on randomly generated DEMs.
 add_executable(excesstopography excesstopography.cpp utils.c)
 if (TT_SANITIZE AND NOT MSVC)
+  # Set up the AddressSanitizer flags
   target_compile_options(random_dem PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
   target_link_options(random_dem PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
 endif()


### PR DESCRIPTION
Fixes #81 

This change adds a bunch of comments to the various `CMakeLists.txt` files throughout the project that explains why we run the various CMake commands. This hopefully makes it easier for future contributors and maintainers to understand the build system.