### PR TITLE
Label the target pixel of sinks/outlets correctly

### DIFF
--- a/src/flow_routing.c
+++ b/src/flow_routing.c
@@ -228,13 +228,17 @@ void flow_routing_targets(ptrdiff_t *target, ptrdiff_t *source,
 
       uint8_t flowdir = direction[node];
 
-      uint8_t v = flowdir;
-      uint8_t r = 0;
-      while (v >>= 1) {
-        r++;
-      }
+      if (flowdir == 0) {
+        target[j * dims[0] + i] = -1;
+      } else {
+        uint8_t v = flowdir;
+        uint8_t r = 0;
+        while (v >>= 1) {
+          r++;
+        }
 
-      target[j * dims[0] + i] = node + offsets[r];
+        target[j * dims[0] + i] = node + offsets[r];
+      }
     }
   }
 }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -396,18 +396,29 @@ int32_t test_flow_routing_targets(ptrdiff_t *target, ptrdiff_t *source,
       ptrdiff_t u_i = u % dims[0];
       ptrdiff_t u_j = u / dims[0];
 
+      assert(u_i >= 0 && u_i < dims[0]);
+      assert(u_j >= 0 && u_j < dims[1]);
+
       uint8_t flowdir = direction[u];
-      uint8_t r = 0;
-      while (flowdir >>= 1) {
-        r++;
+
+      if (flowdir == 0) {
+        assert(target[j * dims[0] + i] == -1);
+      } else {
+        uint8_t r = 0;
+        while (flowdir >>= 1) {
+          r++;
+        }
+
+        ptrdiff_t neighbor_i = u_i + i_offset[r];
+        ptrdiff_t neighbor_j = u_j + j_offset[r];
+
+        assert(neighbor_i >= 0 && neighbor_i < dims[0]);
+        assert(neighbor_j >= 0 && neighbor_j < dims[1]);
+
+        ptrdiff_t v = neighbor_j * dims[0] + neighbor_i;
+
+        assert(v == target[j * dims[0] + i]);
       }
-
-      ptrdiff_t neighbor_i = u_i + i_offset[r];
-      ptrdiff_t neighbor_j = u_j + j_offset[r];
-
-      ptrdiff_t v = neighbor_j * dims[0] + neighbor_i;
-
-      assert(v == target[j * dims[0] + i]);
     }
   }
   return 0;


### PR DESCRIPTION
Fixes #119

When a pixel has no downstream neighbors, its flow direction is set to 0 in `flow_routing_d8_carve`. The target pixel of such a pixel is undefined. If it points to itself, then the flow accumulation of that pixel will be doubled unless the `source==target` condition is checked. It is more useful to set the target pixel to a sentinel value (`-1`) and then check that `target >= 0` whenever it is used.

src/flow_routing.c implements this new behavior
test/random_dem.cpp tests that the downstream pixels are within the array bounds and that pixels with flowdir==0 have target==-1.