### PR TITLE
Compute flow accumulation with a weighted edge list

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -710,6 +710,65 @@ TOPOTOOLBOX_API
 void flow_accumulation(float *acc, ptrdiff_t *source, uint8_t *direction,
                        float *weights, ptrdiff_t dims[2]);
 
+/**
+   @brief Compute flow accumulation based on a weighted edge list
+
+   Accumulates flow by summing contributing areas along flow paths.
+
+   @param[out] acc The computed flow accumulation
+   @parblock
+   A pointer to a `float` array of size `dims[0]` x `dims[1]`
+   @endparblock
+
+   @param[in] source The source pixel for each edge
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The source pixels must be in a topological order.
+   @endparblock
+
+   @param[in] direction The target pixel for each edge
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+   @endparblock
+
+   @param[in] fraction The fraction of flow transported along each edge
+   @parblock
+   A pointer to a `float` array of size `edge_count`
+
+   The fraction for each edge should be a value between zero and one,
+   and the fractions for every edge with the same source pixel should
+   sum to one.
+   @endparblock
+
+   @param[in] weights Initial water depths
+   @parblock
+   A pointer to a `float` array of size `dims[0]` x `dims[1]`
+
+   The initial weights can be used to represent spatially variable
+   precipitation.
+
+   If a null pointer is passed, a default weight of 1.0 for every
+   pixel is used. In this case the resulting flow accumulation is the
+   upstream area in number of pixels.
+   @endparblock
+
+   @param[in] edge_count The number of edges in the edge list
+
+   @param[in] dims The dimensions of the arrays
+   @parblock
+   A pointer to a `ptrdiff_t` array of size 2
+
+   The fastest changing dimension should be provided first. For column-major
+   arrays, `dims = {nrows,ncols}`. For row-major arrays, `dims = {ncols,nrows}`.
+   @endparblock
+ */
+TOPOTOOLBOX_API
+void flow_accumulation_edgelist(float *acc, ptrdiff_t *source,
+                                ptrdiff_t *target, float *fraction,
+                                float *weights, ptrdiff_t edge_count,
+                                ptrdiff_t dims[2]);
+
 #include "graphflood/define_types.h"
 
 /**

--- a/src/flow_accumulation.c
+++ b/src/flow_accumulation.c
@@ -6,6 +6,33 @@
 
 #include "topotoolbox.h"
 
+TOPOTOOLBOX_API
+void flow_accumulation_edgelist(float *acc, ptrdiff_t *source,
+                                ptrdiff_t *target, float *fraction,
+                                float *weights, ptrdiff_t edge_count,
+                                ptrdiff_t dims[2]) {
+  // Initialize with the weights
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      acc[j * dims[0] + i] =
+          (weights == NULL) ? 1.0f : weights[j * dims[0] + i];
+    }
+  }
+
+  for (ptrdiff_t edge = 0; edge < edge_count; edge++) {
+    ptrdiff_t src = source[edge];
+    ptrdiff_t tgt = target[edge];
+    ptrdiff_t w = fraction[edge];
+
+    // Ensure that src and tgt are valid pixels before accumulating.
+    if (src >= 0 && src < dims[0] * dims[1] && tgt >= 0 &&
+        tgt < dims[0] * dims[1]) {
+      acc[tgt] += w * acc[src];
+    }
+  }
+}
+
+TOPOTOOLBOX_API
 void flow_accumulation(float *acc, ptrdiff_t *source, uint8_t *direction,
                        float *weights, ptrdiff_t dims[2]) {
   ptrdiff_t i_offset[8] = {0, 1, 1, 1, 0, -1, -1, -1};

--- a/src/flow_accumulation.c
+++ b/src/flow_accumulation.c
@@ -22,7 +22,7 @@ void flow_accumulation_edgelist(float *acc, ptrdiff_t *source,
   for (ptrdiff_t edge = 0; edge < edge_count; edge++) {
     ptrdiff_t src = source[edge];
     ptrdiff_t tgt = target[edge];
-    ptrdiff_t w = fraction[edge];
+    float w = fraction[edge];
 
     // Ensure that src and tgt are valid pixels before accumulating.
     if (src >= 0 && src < dims[0] * dims[1] && tgt >= 0 &&


### PR DESCRIPTION
This function computes the same thing as `flow_accumulation`, but it uses a weighted edge list rather than the source pixel and flow direction.

This presents a more convenient interface for certain downstream applications which otherwise need to carry around the flow direction raster. It should also work equally well for multiple and single flow directions because it supports edge weights and edge lists that are of a different size than the DEM.

include/topotoolbox.h has the function declaration.

src/flow_accumulation.c implements `flow_accumulation_edgelist`

test/random_dem.cpp runs `flow_accumulation_edgelist` and checks to make sure it has identical results to `flow_accumulation`.

---
@Teschl: This might be useful once it is merged for the `StreamObject` constructor. You wouldn't have to store the flow direction raster in the `FlowObject` and could just use the source and target lists.