### PR TITLE
Move declaration of `gradient8` and its Doxygen comment

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -769,6 +769,31 @@ void flow_accumulation_edgelist(float *acc, ptrdiff_t *source,
                                 float *weights, ptrdiff_t edge_count,
                                 ptrdiff_t dims[2]);
 
+/**
+   @brief Compute  the gradient for each cell in the provided DEM array.
+   The gradient is calculated as the maximum slope between the cell and its
+   8 neighboring cells. The result can be output in different units based on the
+   `unit` parameter, and the computation can be parallelized using OpenMP.
+
+   @param[out] output: Array to store the computed gradient values for each
+   cell. It should have the same dimensions as the DEM.
+   @param[in]  dem: Input digital elevation model as a 2D array flattened into a
+   1D array. This array represents the elevation values of each cell.
+   @param[in]  cellsize: The spatial resolution of the DEM (i.e., the size of
+   each cell).
+   @param[in]  use_mp: If set to 1, enables parallel processing using OpenMP.
+                       If set to 0, the function runs on a single thread.
+   @param[in]  dims: An array specifying the dimensions of the DEM.
+                     It should contain two values: [rows, columns].
+*/
+TOPOTOOLBOX_API
+void gradient8(float *output, float *dem, float cellsize, int use_mp,
+               ptrdiff_t dims[2]);
+
+/*
+  Graphflood
+*/
+
 #include "graphflood/define_types.h"
 
 /**
@@ -876,26 +901,6 @@ void compute_drainage_area_single_flow(GF_FLOAT *output, GF_UINT *Sreceivers,
    @param[in]  dx: spatial step
 */
 TOPOTOOLBOX_API
-void gradient8(float *output, float *dem, float cellsize, int use_mp,
-               ptrdiff_t dims[2]);
-/**
-   @brief Compute  the gradient for each cell in the provided DEM array.
-   The gradient is calculated as the maximum slope between the cell and its
-   8 neighboring cells. The result can be output in different units based on the
-   `unit` parameter, and the computation can be parallelized using OpenMP.
-
-   @param[out] output: Array to store the computed gradient values for each
-   cell. It should have the same dimensions as the DEM.
-   @param[in]  dem: Input digital elevation model as a 2D array flattened into a
-   1D array. This array represents the elevation values of each cell.
-   @param[in]  cellsize: The spatial resolution of the DEM (i.e., the size of
-   each cell).
-   @param[in]  use_mp: If set to 1, enables parallel processing using OpenMP.
-                       If set to 0, the function runs on a single thread.
-   @param[in]  dims: An array specifying the dimensions of the DEM.
-                     It should contain two values: [rows, columns].
-*/
-TOPOTOOLBOX_API
 void compute_weighted_drainage_area_single_flow(GF_FLOAT *output,
                                                 GF_FLOAT *weights,
                                                 GF_UINT *Sreceivers,
@@ -926,5 +931,4 @@ void graphflood_full(GF_FLOAT *Z, GF_FLOAT *hw, uint8_t *BCs,
                      GF_FLOAT *Precipitations, GF_FLOAT *manning, GF_UINT *dim,
                      GF_FLOAT dt, GF_FLOAT dx, bool SFD, bool D8,
                      GF_UINT N_iterations);
-
 #endif  // TOPOTOOLBOX_H


### PR DESCRIPTION
`gradient8` got put in between a Graphflood function and its Doxygen comment.