### PR TITLE
Read DEM size from command line

### DIFF
--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <string>
 #include <vector>
 
 // Include topotoolbox.h in its own namespace to help prevent naming
@@ -673,7 +674,18 @@ struct FlowRoutingData {
 };
 
 int main(int argc, char *argv[]) {
+  // Default size of the DEM
   ptrdiff_t dims[2] = {100, 200};
+
+  if (argc == 3) {
+    // If two integers are passed on the command line, use those for
+    // the size.
+
+    // This will throw an exception if the inputs cannot be
+    // parsed as integers.
+    dims[0] = std::stoll(argv[1]);
+    dims[1] = std::stoll(argv[2]);
+  }
 
   for (uint32_t test = 0; test < 100; test++) {
     FlowRoutingData frd(dims, 10.0, test);


### PR DESCRIPTION
This allows benchmarking runs to use differently sized DEMs. The test that CTest runs, defined in test/CMakeLists.txt, does not pass command line arguments and will use the previous default size.