### PR TITLE
Implement block profiler

### DIFF
--- a/test/profiler.h
+++ b/test/profiler.h
@@ -1,0 +1,94 @@
+#ifndef TT_PROFILER_H
+#define TT_PROFILER_H
+
+/*
+  A basic profiler for libtopotoolbox.
+
+  Usage:
+  1. `#include "profiler.h"` in your test executable.
+  2. Create a profiler with `Profiler prof;`. It is easiest to create a
+     global variable so that everything can access it, but you can also pass it
+     by reference into the functions that need it.
+  3. Put `ProfileBlock(prof,label);` at the start of each block scope
+     in the test executable file you want to time. `label` should be a string
+     literal that labels the block. You can use `ProfileFunction(prof)` to
+     profile a function, in which case the label is the name of the function.
+  4. Call `prof.report()` when you are finished to print the profiling results.
+
+  The output is a JSON object with a single field "blocks" that
+  points to an array of objects of the form
+
+  `{"label" : label of block or name of function,
+    "calls": number of calls of that function during the test,
+    "time": average time per call in milliseconds
+    }`
+
+  Known Limitations:
+
+  - Recursive and nested function calls can lead to misleading results.
+ */
+
+#include <cstdint>
+#include <ctime>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#define ProfileBlock(Profiler, Label) \
+  ProfileZone block##__LINE__(Profiler, Label);
+#define ProfileFunction(Profiler) \
+  ProfileZone block##__LINE__(Profiler, __func__);
+
+struct ProfileStats {
+  uint64_t elapsed;
+  uint64_t count;
+};
+
+struct Profiler {
+  void report() {
+    std::cout << "{\"blocks\": [" << std::endl;
+    int count = 0;
+    for (auto iter = anchors.begin(); iter != anchors.end(); ++iter) {
+      if (iter->second.count > 0) {
+        if (count != 0) {
+          std::cout << "," << std::endl;
+        }
+        double anchor_ms = 1000.0 * iter->second.elapsed /
+                           (double)CLOCKS_PER_SEC / iter->second.count;
+
+        std::cout << "{\"label\": \"" << iter->first << "\"," << std::endl;
+        std::cout << "\"calls\": " << iter->second.count << "," << std::endl;
+        std::cout << "\"time\": " << anchor_ms << "}" << std::endl;
+        count++;
+      }
+    }
+    std::cout << "]}" << std::endl;
+  }
+
+  ProfileStats &operator[](std::string label) { return anchors[label]; }
+
+ private:
+  std::unordered_map<std::string, ProfileStats> anchors;
+};
+
+struct ProfileZone {
+  ProfileZone(Profiler &prof_, const char *label_)
+      : label(label_), prof(prof_) {
+    start = std::clock();
+  }
+
+  ~ProfileZone(void) {
+    uint64_t elapsed = std::clock() - start;
+
+    ProfileStats &anchor = prof[label];
+    anchor.elapsed += elapsed;
+    anchor.count++;
+  }
+
+ private:
+  const char *label;
+  uint64_t start;
+  Profiler &prof;
+};
+
+#endif  // TT_PROFILER_H

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -19,6 +20,9 @@ extern "C" {
 extern "C" {
 #include "utils.h"
 }
+
+#include "profiler.h"
+Profiler prof;  // Global Profiler that our test functions can access
 
 #define SQRT2f 1.41421356237309504880f
 #define SQRT2 1.41421356237309504880f
@@ -575,6 +579,8 @@ struct FlowRoutingData {
   }
 
   void route_flow() {
+    ProfileFunction(prof);
+
     tt::fillsinks(filled_dem.data(), dem.data(), dims.data());
 
     tt::identifyflats(flats.data(), filled_dem.data(), dims.data());
@@ -595,9 +601,13 @@ struct FlowRoutingData {
     tt::flow_accumulation_edgelist(accum2.data(), source.data(), target.data(),
                                    fraction.data(), NULL, dims[0] * dims[1],
                                    dims.data());
+
+    // Close timer
   }
 
   void route_flow_hybrid() {
+    ProfileFunction(prof);
+
     tt::fillsinks_hybrid(filled_dem.data(), queue.data(), dem.data(),
                          dims.data());
 
@@ -622,10 +632,14 @@ struct FlowRoutingData {
   }
 
   void gradient8() {
+    ProfileFunction(prof);
+
     tt::gradient8(gradient.data(), dem.data(), cellsize, 0, dims.data());
   }
 
   void gradient8_mp() {
+    ProfileFunction(prof);
+
     tt::gradient8(gradient_mp.data(), dem.data(), cellsize, 1, dims.data());
   }
 
@@ -698,4 +712,5 @@ int main(int argc, char *argv[]) {
       frd.runtests(false);
     }
   }
+  prof.report();
 }


### PR DESCRIPTION
This commit adds a very simple block profiler. The profiler times how long it takes to execute a block, sums the total elapsed time for a given block that may be executed more than once by the test, and prints the results. See the comment at the top of test/profiler.h for usage instructions and caveats.

The profiling code should have minimal overhead, so it will not interfere with the normal automated testing procedure. Proper benchmarks using this profiler should be run on dedicated hardware (i.e. not on CI) with CMAKE_BUILD_TYPE=Release.

test/profiler.h implements the block profiler

test/random_dem.cpp profiles the `route_flow`, `route_flow_hybrid`, `gradient8` and `gradient8_mp` member functions of the `FlowRoutingData` class.