### PR TITLE
Lint JSON output of profiler with jq on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,8 @@ jobs:
         run: cmake --build ${{github.workspace}}/build/static --config Release
       - name: Test static library
         run: ctest --test-dir ${{github.workspace}}/build/static -C Release --output-on-failure
+      - name: Validate JSON output of profiler
+        run: ${{github.workspace}}/build/static/test/random_dem | jq -e .
       - name: Configure shared library
         run: >
           cmake -B ${{github.workspace}}/build/shared


### PR DESCRIPTION
The release build will now directly run the random_dem test executable, which includes output from the profiler, and pass the results through `jq`, which is included in the GitHub-provided runners. Any invalid JSON produced by the profiler will cause jq and the automated check to fail.