### PR TITLE
Graphflood patch

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -934,6 +934,8 @@ void compute_weighted_drainage_area_single_flow(GF_FLOAT *output,
    @param[in]     D8: true for topology including cardinals + diagonals,
    false for cardinals only
    @param[in]     N_iterations: number of iterations of the flooding algorithm
+   @param[in]     step: delta_Z to apply minimum elevation increase and avoid
+   flats, false for cardinals only
 */
 TOPOTOOLBOX_API
 void graphflood_full(GF_FLOAT *Z, GF_FLOAT *hw, uint8_t *BCs,

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -846,10 +846,11 @@ void compute_sfgraph_priority_flood(GF_FLOAT *topo, GF_UINT *Sreceivers,
    @param[in]     dim: [rows,columns] if row major and [columns, rows] if
    column major
    @param[in]     D8: true for topology including cardinals + diagonals,
+   @param[in]     step: delta_Z to apply minimum elevation increase and avoid flats,
    false for cardinals only
 */
 TOPOTOOLBOX_API
-void compute_priority_flood(float *topo, uint8_t *BCs, GF_UINT *dim, bool D8);
+void compute_priority_flood(GF_FLOAT *topo, uint8_t *BCs, GF_UINT *dim, bool D8, GF_FLOAT step);
 
 /**
    @brief Fills the depressions in place in the topography using Priority
@@ -865,13 +866,15 @@ void compute_priority_flood(float *topo, uint8_t *BCs, GF_UINT *dim, bool D8);
    @param[in]     dim: [rows,columns] if row major and [columns, rows] if
    column major
    @param[in]     D8: true for topology including cardinals + diagonals,
+   @param[in]     step: delta_Z to apply minimum elevation increase and avoid flats,
    false for cardinals only
 */
 TOPOTOOLBOX_API
-void compute_priority_flood_plus_topological_ordering(float *topo,
+void compute_priority_flood_plus_topological_ordering(GF_FLOAT *topo,
                                                       GF_UINT *Stack,
                                                       uint8_t *BCs,
-                                                      GF_UINT *dim, bool D8);
+                                                      GF_UINT *dim, bool D8,
+                                                      GF_FLOAT step);
 
 /**
    @brief Accumulate single flow drainage area downstream from a calculated

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -938,5 +938,5 @@ TOPOTOOLBOX_API
 void graphflood_full(GF_FLOAT *Z, GF_FLOAT *hw, uint8_t *BCs,
                      GF_FLOAT *Precipitations, GF_FLOAT *manning, GF_UINT *dim,
                      GF_FLOAT dt, GF_FLOAT dx, bool SFD, bool D8,
-                     GF_UINT N_iterations);
+                     GF_UINT N_iterations, GF_FLOAT step);
 #endif  // TOPOTOOLBOX_H

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -846,11 +846,12 @@ void compute_sfgraph_priority_flood(GF_FLOAT *topo, GF_UINT *Sreceivers,
    @param[in]     dim: [rows,columns] if row major and [columns, rows] if
    column major
    @param[in]     D8: true for topology including cardinals + diagonals,
-   @param[in]     step: delta_Z to apply minimum elevation increase and avoid flats,
-   false for cardinals only
+   @param[in]     step: delta_Z to apply minimum elevation increase and avoid
+   flats, false for cardinals only
 */
 TOPOTOOLBOX_API
-void compute_priority_flood(GF_FLOAT *topo, uint8_t *BCs, GF_UINT *dim, bool D8, GF_FLOAT step);
+void compute_priority_flood(GF_FLOAT *topo, uint8_t *BCs, GF_UINT *dim, bool D8,
+                            GF_FLOAT step);
 
 /**
    @brief Fills the depressions in place in the topography using Priority
@@ -866,8 +867,8 @@ void compute_priority_flood(GF_FLOAT *topo, uint8_t *BCs, GF_UINT *dim, bool D8,
    @param[in]     dim: [rows,columns] if row major and [columns, rows] if
    column major
    @param[in]     D8: true for topology including cardinals + diagonals,
-   @param[in]     step: delta_Z to apply minimum elevation increase and avoid flats,
-   false for cardinals only
+   @param[in]     step: delta_Z to apply minimum elevation increase and avoid
+   flats, false for cardinals only
 */
 TOPOTOOLBOX_API
 void compute_priority_flood_plus_topological_ordering(GF_FLOAT *topo,

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -834,7 +834,7 @@ void compute_sfgraph_priority_flood(GF_FLOAT *topo, GF_UINT *Sreceivers,
                                     GF_FLOAT *distToReceivers, GF_UINT *Sdonors,
                                     uint8_t *NSdonors, GF_UINT *Stack,
                                     uint8_t *BCs, GF_UINT *dim, GF_FLOAT dx,
-                                    bool D8);
+                                    bool D8, GF_FLOAT step);
 
 /**
    @brief Fills the depressions in place in the topography using Priority

--- a/src/graphflood/graphflood.c
+++ b/src/graphflood/graphflood.c
@@ -22,6 +22,8 @@ void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
                           GF_FLOAT* Precipitations, GF_FLOAT* manning,
                           GF_UINT* dim, GF_FLOAT dt, GF_FLOAT dx, bool SFD,
                           bool D8, GF_UINT N_iterations) {
+
+
   // Creating an array of Zw (hydraulic surface = Z + hw)
   GF_FLOAT* Zw = (GF_FLOAT*)malloc(sizeof(GF_FLOAT) * nxy(dim));
   for (GF_UINT i = 0; i < nxy(dim); ++i) Zw[i] = Z[i] + hw[i];
@@ -41,7 +43,7 @@ void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
     // At each iteration I update the graph while filling every depressions (*in
     // the hydraulic surface) with water
     compute_sfgraph_priority_flood(Zw, Sreceivers, distToReceivers, Sdonors,
-                                   NSdonors, Stack, BCs, dim, dx, D8);
+                                   NSdonors, Stack, BCs, dim, dx, D8, step);
 
     // From the graph hence created I accumulate the flow (steady conditions)
     compute_weighted_drainage_area_single_flow(Qwin, Precipitations, Sreceivers,
@@ -94,7 +96,7 @@ void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
 void _graphflood_full_mfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
                           GF_FLOAT* Precipitations, GF_FLOAT* manning,
                           GF_UINT* dim, GF_FLOAT dt, GF_FLOAT dx, bool SFD,
-                          bool D8, GF_UINT N_iterations) {
+                          bool D8, GF_UINT N_iterations, GF_FLOAT step) {
   // Initialising the offset for neighbouring operations
   GF_INT offset[8];
   (D8 == false) ? generate_offset_D4_flat(offset, dim)
@@ -125,7 +127,7 @@ void _graphflood_full_mfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
 
   for (GF_UINT iteration = 0; iteration < N_iterations; ++iteration) {
     // First priority flooding and calculating stack
-    compute_priority_flood_plus_topological_ordering(Zw, Stack, BCs, dim, D8);
+    compute_priority_flood_plus_topological_ordering(Zw, Stack, BCs, dim, D8, step);
 
     // reintialising Qw
     for (GF_UINT i = 0; i < nxy(dim); ++i) {
@@ -225,12 +227,12 @@ TOPOTOOLBOX_API
 void graphflood_full(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
                      GF_FLOAT* Precipitations, GF_FLOAT* manning, GF_UINT* dim,
                      GF_FLOAT dt, GF_FLOAT dx, bool SFD, bool D8,
-                     GF_UINT N_iterations) {
+                     GF_UINT N_iterations, GF_FLOAT step) {
   // Runs the single flow version of the algorithm
   if (SFD)
     _graphflood_full_sfd(Z, hw, BCs, Precipitations, manning, dim, dt, dx, SFD,
-                         D8, N_iterations);
+                         D8, N_iterations, step);
   else
     _graphflood_full_mfd(Z, hw, BCs, Precipitations, manning, dim, dt, dx, SFD,
-                         D8, N_iterations);
+                         D8, N_iterations, step);
 }

--- a/src/graphflood/graphflood.c
+++ b/src/graphflood/graphflood.c
@@ -22,8 +22,6 @@ void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
                           GF_FLOAT* Precipitations, GF_FLOAT* manning,
                           GF_UINT* dim, GF_FLOAT dt, GF_FLOAT dx, bool SFD,
                           bool D8, GF_UINT N_iterations, GF_FLOAT step) {
-
-
   // Creating an array of Zw (hydraulic surface = Z + hw)
   GF_FLOAT* Zw = (GF_FLOAT*)malloc(sizeof(GF_FLOAT) * nxy(dim));
   for (GF_UINT i = 0; i < nxy(dim); ++i) Zw[i] = Z[i] + hw[i];
@@ -127,7 +125,8 @@ void _graphflood_full_mfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
 
   for (GF_UINT iteration = 0; iteration < N_iterations; ++iteration) {
     // First priority flooding and calculating stack
-    compute_priority_flood_plus_topological_ordering(Zw, Stack, BCs, dim, D8, step);
+    compute_priority_flood_plus_topological_ordering(Zw, Stack, BCs, dim, D8,
+                                                     step);
 
     // reintialising Qw
     for (GF_UINT i = 0; i < nxy(dim); ++i) {

--- a/src/graphflood/graphflood.c
+++ b/src/graphflood/graphflood.c
@@ -21,7 +21,7 @@ direction
 void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
                           GF_FLOAT* Precipitations, GF_FLOAT* manning,
                           GF_UINT* dim, GF_FLOAT dt, GF_FLOAT dx, bool SFD,
-                          bool D8, GF_UINT N_iterations) {
+                          bool D8, GF_UINT N_iterations, GF_FLOAT step) {
 
 
   // Creating an array of Zw (hydraulic surface = Z + hw)

--- a/src/graphflood/priority_flood_standalone.c
+++ b/src/graphflood/priority_flood_standalone.c
@@ -104,7 +104,7 @@ void compute_priority_flood(GF_FLOAT* topo, uint8_t* BCs, GF_UINT* dim, bool D8,
         // nextafter maskes sure I pick the next floating point data
         // corresponding to the current precision
         if (topo[nnode] <=
-            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX)) + step {
+            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step) {
           // raise
           topo[nnode] =
               (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step;

--- a/src/graphflood/priority_flood_standalone.c
+++ b/src/graphflood/priority_flood_standalone.c
@@ -26,7 +26,7 @@ LSS: runs priority floods (Barnes 2014) + epsilon on a topogrpahy
 Fills it in place, and take into D8/D4 topology and custom boundary conditions
 */
 TOPOTOOLBOX_API
-void compute_priority_flood(float* topo, uint8_t* BCs, GF_UINT* dim, bool D8) {
+void compute_priority_flood(GF_FLOAT* topo, uint8_t* BCs, GF_UINT* dim, bool D8, GF_FLOAT step) {
   // Initialising the offset for neighbouring operations
   GF_INT offset[8];
   (D8 == false) ? generate_offset_D4_flat(offset, dim)
@@ -104,10 +104,10 @@ void compute_priority_flood(float* topo, uint8_t* BCs, GF_UINT* dim, bool D8) {
         // nextafter maskes sure I pick the next floating point data
         // corresponding to the current precision
         if (topo[nnode] <=
-            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX)) {
+            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX)) + step {
           // raise
           topo[nnode] =
-              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX);
+              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step;
           // put in pit queue
           pitqueue_enqueue(&pit, nnode);
           // Affect current node as neighbours Sreceiver
@@ -134,10 +134,12 @@ pit (no fifo queue) By experience the slowing down factor is small for most
 cases ( low amount of depressions, ~10% max slow down)
 */
 TOPOTOOLBOX_API
-void compute_priority_flood_plus_topological_ordering(float* topo,
+void compute_priority_flood_plus_topological_ordering(GF_FLOAT* topo,
                                                       GF_UINT* stack,
                                                       uint8_t* BCs,
-                                                      GF_UINT* dim, bool D8) {
+                                                      GF_UINT* dim, 
+                                                      bool D8,
+                                                      GF_FLOAT step) {
   // Initialising the offset for neighbouring operations
   GF_INT offset[8];
   (D8 == false) ? generate_offset_D4_flat(offset, dim)
@@ -208,11 +210,11 @@ void compute_priority_flood_plus_topological_ordering(float* topo,
         // corresponding to the current precision
         if (topo[nnode] <=
             (GF_FLOAT)(nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) +
-                       1e-4)) {
+                       step)) {
           // raise
           topo[nnode] =
               (GF_FLOAT)(nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) +
-                         1e-4);
+                         step);
           // put in pqueue
           pfpq_push(&open, nnode, topo[nnode]);
           // Affect current node as neighbours Sreceiver

--- a/src/graphflood/priority_flood_standalone.c
+++ b/src/graphflood/priority_flood_standalone.c
@@ -26,7 +26,8 @@ LSS: runs priority floods (Barnes 2014) + epsilon on a topogrpahy
 Fills it in place, and take into D8/D4 topology and custom boundary conditions
 */
 TOPOTOOLBOX_API
-void compute_priority_flood(GF_FLOAT* topo, uint8_t* BCs, GF_UINT* dim, bool D8, GF_FLOAT step) {
+void compute_priority_flood(GF_FLOAT* topo, uint8_t* BCs, GF_UINT* dim, bool D8,
+                            GF_FLOAT step) {
   // Initialising the offset for neighbouring operations
   GF_INT offset[8];
   (D8 == false) ? generate_offset_D4_flat(offset, dim)
@@ -104,10 +105,12 @@ void compute_priority_flood(GF_FLOAT* topo, uint8_t* BCs, GF_UINT* dim, bool D8,
         // nextafter maskes sure I pick the next floating point data
         // corresponding to the current precision
         if (topo[nnode] <=
-            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step) {
+            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) +
+                step) {
           // raise
           topo[nnode] =
-              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step;
+              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) +
+              step;
           // put in pit queue
           pitqueue_enqueue(&pit, nnode);
           // Affect current node as neighbours Sreceiver
@@ -137,8 +140,7 @@ TOPOTOOLBOX_API
 void compute_priority_flood_plus_topological_ordering(GF_FLOAT* topo,
                                                       GF_UINT* stack,
                                                       uint8_t* BCs,
-                                                      GF_UINT* dim, 
-                                                      bool D8,
+                                                      GF_UINT* dim, bool D8,
                                                       GF_FLOAT step) {
   // Initialising the offset for neighbouring operations
   GF_INT offset[8];

--- a/src/graphflood/sfgraph.c
+++ b/src/graphflood/sfgraph.c
@@ -146,7 +146,7 @@ void compute_sfgraph_priority_flood(float* topo, GF_UINT* Sreceivers,
                                     GF_FLOAT* distToReceivers, GF_UINT* Sdonors,
                                     uint8_t* NSdonors, GF_UINT* Stack,
                                     uint8_t* BCs, GF_UINT* dim, float dx,
-                                    bool D8) {
+                                    bool D8, GF_FLOAT step) {
   // Initialising the offset for neighbouring operations
   GF_INT offset[8];
   (D8 == false) ? generate_offset_D4_flat(offset, dim)
@@ -265,10 +265,10 @@ void compute_sfgraph_priority_flood(float* topo, GF_UINT* Sreceivers,
         // nextafter maskes sure I pick the next floating point data
         // corresponding to the current precision
         if (topo[nnode] <=
-            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX)) {
+            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step) {
           // raise
           topo[nnode] =
-              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX);
+              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step;
           // put in pit queue
           pitqueue_enqueue(&pit, nnode);
           // Affect current node as neighbours Sreceiver

--- a/src/graphflood/sfgraph.c
+++ b/src/graphflood/sfgraph.c
@@ -265,10 +265,12 @@ void compute_sfgraph_priority_flood(float* topo, GF_UINT* Sreceivers,
         // nextafter maskes sure I pick the next floating point data
         // corresponding to the current precision
         if (topo[nnode] <=
-            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step) {
+            (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) +
+                step) {
           // raise
           topo[nnode] =
-              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) + step;
+              (GF_FLOAT)nextafter((GF_FLOAT)topo[node], (GF_FLOAT)FLT_MAX) +
+              step;
           // put in pit queue
           pitqueue_enqueue(&pit, nnode);
           // Affect current node as neighbours Sreceiver


### PR DESCRIPTION
This PR patches earlier versions of `graphflood`. These changes need to go ahead before I finish the PR the python frontend (TopoToolbox/pytopotoolbox#57).

After more testing and use, I realised that my custom priority flood (tailored for use with `graphflood`, not for general use - or it can but it require a specific format of boundary condition codes) was sometimes falling bellow floating point precision when trying to impose a minimum slope. I added an argument allowing user to control the magnitude of the imposed slope.