### PR TITLE
Supply boundary conditions to `fillsinks` and `fillsinks_hybrid`

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -63,6 +63,18 @@ int has_topotoolbox(void);
    A pointer to a `float` array of size `dims[0]` x `dims[1]`
    @endparblock
 
+   @param[in] bc Array used to set boundary conditions
+   @parblock
+   A pointer to a `uint8_t` array of size `dims[0]` x `dims[1]`
+
+   `bc` is used to control which pixels get filled. Pixels that are
+   set equal to 1 are fixed to their value in the input DEM while
+   pixels equal to 0 are filled. For the standard fillsinks operation,
+   bc equals 1 on the boundaries of the DEM and 0 on the interior. Set
+   bc equal to 1 for NaN pixels to ensure that they are treated as
+   sinks.
+   @endparblock
+
    @param[in] dims The dimensions of the arrays
    @parblock
    A pointer to a `ptrdiff_t` array of size 2
@@ -72,7 +84,7 @@ int has_topotoolbox(void);
    @endparblock
  */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
+void fillsinks(float *output, float *dem, uint8_t *bc, ptrdiff_t dims[2]);
 
 /**
    @brief Fills sinks in a digital elevation model
@@ -109,6 +121,18 @@ void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
    A pointer to a `float` array of size `dims[0]` x `dims[1]`
    @endparblock
 
+   @param[in] bc Array used to set boundary conditions
+   @parblock
+   A pointer to a `uint8_t` array of size `dims[0]` x `dims[1]`
+
+   `bc` is used to control which pixels get filled. Pixels that are
+   set equal to 1 are fixed to their value in the input DEM while
+   pixels equal to 0 are filled. For the standard fillsinks operation,
+   bc equals 1 on the boundaries of the DEM and 0 on the interior. Set
+   bc equal to 1 for NaN pixels to ensure that they are treated as
+   sinks.
+   @endparblock
+
    @param[in] dims The dimensions of the arrays
    @parblock
    A pointer to a `ptrdiff_t` array of size 2
@@ -118,7 +142,7 @@ void fillsinks(float *output, float *dem, ptrdiff_t dims[2]);
    @endparblock
  */
 TOPOTOOLBOX_API
-void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem,
+void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem, uint8_t *bc,
                       ptrdiff_t dims[2]);
 
 /**

--- a/src/fillsinks.c
+++ b/src/fillsinks.c
@@ -21,7 +21,7 @@
   Sinks are filled using grayscale morphological reconstruction.
 */
 TOPOTOOLBOX_API
-void fillsinks(float *output, float *dem, ptrdiff_t dims[2]) {
+void fillsinks(float *output, float *dem, uint8_t *bc, ptrdiff_t dims[2]) {
   for (ptrdiff_t j = 0; j < dims[1]; j++) {
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
       // Invert the DEM
@@ -29,7 +29,7 @@ void fillsinks(float *output, float *dem, ptrdiff_t dims[2]) {
 
       // Set the boundary pixels of the output equal to the DEM and
       // the interior pixels equal to -INFINITY.
-      if ((i == 0 || i == (dims[0] - 1)) || (j == 0 || j == (dims[1] - 1))) {
+      if (bc[j * dims[0] + i] == 1) {
         output[j * dims[0] + i] = dem[j * dims[0] + i];
       } else {
         output[j * dims[0] + i] = -INFINITY;
@@ -49,7 +49,7 @@ void fillsinks(float *output, float *dem, ptrdiff_t dims[2]) {
 }
 
 TOPOTOOLBOX_API
-void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem,
+void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem, uint8_t *bc,
                       ptrdiff_t dims[2]) {
   for (ptrdiff_t j = 0; j < dims[1]; j++) {
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
@@ -58,7 +58,7 @@ void fillsinks_hybrid(float *output, ptrdiff_t *queue, float *dem,
 
       // Set the boundary pixels of the output equal to the DEM and
       // the interior pixels equal to -INFINITY.
-      if ((i == 0 || i == (dims[0] - 1)) || (j == 0 || j == (dims[1] - 1))) {
+      if (bc[j * dims[0] + i] == 1) {
         output[j * dims[0] + i] = dem[j * dims[0] + i];
       } else {
         output[j * dims[0] + i] = -INFINITY;

--- a/src/morphology/reconstruct.c
+++ b/src/morphology/reconstruct.c
@@ -75,7 +75,7 @@ ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t dims[2]) {
       ptrdiff_t p = j * dims[0] + i;
 
       // Compute the maximum of the marker at the current pixel and all
-      // of its previously visisted neighbors
+      // of its previously visited neighbors
       float max_height = marker[p];
       for (ptrdiff_t neighbor = 0; neighbor < 4; neighbor++) {
         ptrdiff_t neighbor_i = i + i_offset[neighbor];
@@ -89,20 +89,21 @@ ptrdiff_t forward_scan(float *marker, float *mask, ptrdiff_t dims[2]) {
           continue;
         }
 
-        max_height = max_height > marker[q] ? max_height : marker[q];
+        max_height = fmaxf(max_height, marker[q]);
       }
 
       // Set the marker at the current pixel to the minimum of the
       // maximum height of the neighborhood and the mask at the current
       // pixel.
 
+      // If mask[p] is NaN, this will set z = NaN
       float z = max_height < mask[p] ? max_height : mask[p];
 
-      if (z != marker[p]) {
+      if (z > marker[p]) {
         // Increment count only if we change the current pixel
         count++;
-        marker[p] = z;
       }
+      marker[p] = z;
     }
   }
   return count;
@@ -155,19 +156,19 @@ ptrdiff_t backward_scan(float *marker, PixelQueue *queue, float *mask,
             neighbor_j >= dims[1]) {
           continue;
         }
-        max_height = max_height > marker[q] ? max_height : marker[q];
+        max_height = fmaxf(max_height, marker[q]);
       }
 
       // Set the marker at the current pixel to the minimum of the
       // maximum height of the neighborhood and the mask at the current
       // pixel.
-
       float z = max_height < mask[p] ? max_height : mask[p];
-      if (z != marker[p]) {
+
+      if (z > marker[p]) {
         // Increment count only if we change the current pixel
         count++;
-        marker[p] = z;
       }
+      marker[p] = z;
 
       if (queue) {
         // Scan the neighborhood again to check if the pixel should be
@@ -225,7 +226,7 @@ int32_t propagate(float *marker, PixelQueue *queue, float *mask,
         continue;
       }
 
-      if ((marker[q] < pz) && (mask[q] != marker[q])) {
+      if ((marker[q] < pz) && (marker[q] < mask[q])) {
         // Update the neighbor only if it meets the above criteria
         marker[q] = fminf(pz, mask[q]);
 


### PR DESCRIPTION
The new `bc` argument to `fillsinks` and `fillsinks_hybrid` is a `uint8_t` array of the same dimension as the DEM with a value of 1 at each pixel that should be pinned to its original values in the DEM and 0 otherwise. This allows some additional flexibility in determining the "boundary" of the DEM. For example, if you only wanted to fill a smaller region within a DEM.

It also allows us to flag NaNs, so that we can reproduce the behavior of TopoToolbox v2 with NaNs, resolving #20. Specifically, if pixel `p` of the DEM is a NaN, then setting `dem[p] = -INFINITY` and `bc[p] = 1`, will prevent that pixel from being filled, treating it as a known sink, which is the existing behavior of TopoToolbox v2.

Some changes are also made to src/morphology/reconstruct.c to ensure that the comparisons work properly if there are NaNs in the mask image supplied to `reconstruct`. A NaN is treated as a missing value, so that its presence does not influence its neighbors one way or the other. Pixels will be filled according to the grayscale reconstruction formula as if their neighborhoods do not include neighboring NaNs.

I have not included tests of the new boundary condition behavior, though the `random_dem.cpp` tests have been adapted to use the new `bc` argument with the standard boundaries. Property-based tests could be added to ensure that the boundary pixels are processed correctly. The forthcoming snapshot tests may also be useful for verifying fillsinks when NaNs are preprocessed in different ways.

@Teschl: this will be a breaking change for pytopotoolbox because the APIs for `fillsinks` and `fillsinks_hybrid` are different. Once I merge this PR, I'll open an issue in pytopotoolbox to make sure we pass in the correct `bc` argument to `fillsinks`.