### PR TITLE
Implement snapshot testing framework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: ["main"]
   push:
-    branches: ["main"]
+    branches: ["main","snapshot-tests"]
 
 jobs:
   format-check:
@@ -18,10 +18,16 @@ jobs:
           clang-format-version: '14'
   debug-build:
     runs-on: ubuntu-latest
+    env:
+      snapshot_version: v1.3.0
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install OpenMP
         run: sudo apt-get install -y libomp-dev
+      - name: Install GDAL
+        run: sudo apt install libgdal-dev
       - name: Install doxygen
         run: |
           sudo apt update
@@ -29,6 +35,21 @@ jobs:
       - name: Install Python build dependencies
         run: |
           pip install -r ${{github.workspace}}/docs/requirements.txt
+      - name: Cache snapshot data
+        id: cache-snapshots-debug
+        uses: actions/cache@v4
+        with:
+          path: test/snapshots
+          key: snapshots-${{ env.snapshot_version }}
+      - name: Download and extract snapshot data
+        if: steps.cache-snapshots-debug.outputs.cache-hit != 'true'
+        working-directory: test/snapshots
+        shell: bash
+        run: |
+          curl -L -o snapshot_data.tar.gz \
+          "https://github.com/TopoToolbox/snapshot_data/releases/download/$snapshot_version/snapshot_data.tar.gz"
+          tar -xzf snapshot_data.tar.gz
+          shasum -c --status sha256sum.txt
       - name: Configure
         run: >
           cmake -B ${{github.workspace}}/build/debug
@@ -45,6 +66,8 @@ jobs:
         run: ctest --test-dir ${{github.workspace}}/build/debug -C Debug --output-on-failure
   release-build:
     runs-on: ${{ matrix.os }}
+    env:
+      snapshot_version: v1.3.0
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +93,8 @@ jobs:
             c_compiler: cl
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install OpenMP on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libomp-dev
@@ -79,6 +104,10 @@ jobs:
       - name: Set OpenMP_ROOT on macOS
         if: matrix.os == 'macos-latest'
         run: echo "OpenMP_ROOT=$(brew --prefix)/opt/libomp" >> $GITHUB_ENV
+      - name: Install GDAL on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libgdal-dev
+        ## TODO: Install GDAL on Windows and macos
       - name: Install ninja on windows
         uses: seanmiddleditch/gha-setup-ninja@master
         if: matrix.os == 'windows-latest'
@@ -90,6 +119,22 @@ jobs:
         run: |
           echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
           echo "CMAKE_CONFIGURATION_TYPES=Release" >> "$env:GITHUB_ENV"
+      - name: Cache snapshot data
+        if: matrix.os == 'ubuntu-latest'
+        id: cache-snapshots-release
+        uses: actions/cache@v4
+        with:
+          path: test/snapshots
+          key: snapshots-${{ env.snapshot_version }}
+      - name: Download and extract snapshot data
+        if: matrix.os == 'ubuntu-latest' && steps.cache-snapshots-release.outputs.cache-hit != 'true'
+        working-directory: test/snapshots
+        shell: bash
+        run: |
+          curl -L -o snapshot_data.tar.gz \
+          "https://github.com/TopoToolbox/snapshot_data/releases/download/$snapshot_version/snapshot_data.tar.gz"
+          tar -xzf snapshot_data.tar.gz
+          shasum -c --status sha256sum.txt
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/snapshots"]
+	path = test/snapshots
+	url = https://github.com/TopoToolbox/snapshot_data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Language standards and compiler settings
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,3 +55,26 @@ target_link_libraries(excesstopography PRIVATE topotoolbox)
 add_test(NAME excesstopography COMMAND excesstopography)
 set_tests_properties(excesstopography PROPERTIES ENVIRONMENT_MODIFICATION
   "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
+
+# TEST: snapshots
+#
+# Runs the snapshot tests from available snapshot data
+include(FindGDAL)
+
+if (GDAL_FOUND)
+  add_executable(snapshot snapshot.cpp utils.c)
+  if (TT_SANITIZE AND NOT MSVC)
+    # Set up the AddressSanitizer flags
+    target_compile_options(random_dem PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
+    target_link_options(random_dem PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
+  endif()
+  target_link_libraries(snapshot PRIVATE topotoolbox GDAL::GDAL)
+
+  # Copy test snapshots to output
+  add_custom_target(copy-test-files ALL
+    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/snapshots ${CMAKE_CURRENT_BINARY_DIR}/snapshots)
+
+  add_test(NAME snapshot COMMAND snapshot snapshots/data)
+  set_tests_properties(snapshot PROPERTIES ENVIRONMENT_MODIFICATION
+    "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
+endif()

--- a/test/snapshot.cpp
+++ b/test/snapshot.cpp
@@ -1,0 +1,144 @@
+#undef NDEBUG
+
+#include <gdal_priv.h>
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace tt {
+extern "C" {
+#include "topotoolbox.h"
+}
+}  // namespace tt
+
+#include "profiler.h"
+Profiler prof;
+
+template <typename T, GDALDataType S>
+void load_data_from_file(const std::string& filename, std::vector<T>& output,
+                         std::array<ptrdiff_t, 2>& dims) {
+  GDALDataset* dataset = GDALDataset::Open(filename.data(), GA_ReadOnly);
+
+  GDALRasterBand* poBand = dataset->GetRasterBand(1);
+  dims[0] = poBand->GetXSize();
+  dims[1] = poBand->GetYSize();
+
+  output.resize(dims[0] * dims[1]);
+
+  assert(poBand->RasterIO(GF_Read, 0, 0, dims[0], dims[1], output.data(),
+                          dims[0], dims[1], S, 0, 0) == CE_None);
+
+  GDALClose(dataset);
+}
+
+struct SnapshotData {
+  std::array<ptrdiff_t, 2> dims;
+  float cellsize;
+
+  std::vector<float> dem;
+  std::vector<float> filled_dem;
+
+  // Output arrays
+  std::vector<float> test_dem;
+  std::vector<float> test_filled_dem;
+
+  // Intermediate arrays
+  std::vector<uint8_t> bc;
+
+  SnapshotData(const std::filesystem::path& snapshot_path) {
+    GDALAllRegister();
+
+    if (exists(snapshot_path / "dem.tif")) {
+      load_data_from_file<float, GDT_Float32>(snapshot_path / "dem.tif", dem,
+                                              dims);
+      test_dem = dem;  // Create a copy of the DEM to modify in fillsinks
+      assert(test_dem.size() == dem.size());
+    }
+
+    std::array<ptrdiff_t, 2> dims_check;
+    if (exists(snapshot_path / "fillsinks.tif")) {
+      load_data_from_file<float, GDT_Float32>(snapshot_path / "fillsinks.tif",
+                                              filled_dem, dims_check);
+      assert(dims[0] == dims_check[0] && dims[1] == dims_check[1]);
+    }
+
+    // Allocate and resize output and intermediate arrays
+    if (dem.size() > 0) {
+      if (filled_dem.size() > 0) {
+        // Boundary conditions
+        bc.resize(dims[0] * dims[1]);
+        test_filled_dem.resize(dims[0] * dims[1]);
+      }
+    }
+  }
+
+  void runtests() {
+    // fillsinks
+    if (test_filled_dem.size() > 0) {
+      // Initialize bcs
+      for (ptrdiff_t j = 0; j < dims[1]; j++) {
+        for (ptrdiff_t i = 0; i < dims[0]; i++) {
+          if (isnan(dem[j * dims[0] + i])) {
+            bc[j * dims[0] + i] = 1;
+            test_dem[j * dims[0] + i] = -INFINITY;
+          } else {
+            if (i == 0 || i == dims[0] - 1 || j == 0 || j == dims[1] - 1) {
+              // 1 on the boundaries
+              bc[j * dims[0] + i] = 1;
+            } else {
+              // 0 on the interior
+              bc[j * dims[0] + i] = 0;
+            }
+          }
+        }
+      }
+
+      tt::fillsinks(test_filled_dem.data(), test_dem.data(), bc.data(),
+                    dims.data());
+
+      for (ptrdiff_t j = 0; j < dims[1]; j++) {
+        for (ptrdiff_t i = 0; i < dims[0]; i++) {
+          if (!isnan(filled_dem[j * dims[0] + i])) {
+            assert(test_filled_dem[j * dims[0] + i] ==
+                   filled_dem[j * dims[0] + i]);
+          }
+        }
+      }
+    }
+  }
+};
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cout << "Usage: snapshot <snapshot_directory>" << std::endl;
+    return 0;
+  }
+
+  // Get the snapshot directory path from the command line arguments
+  std::filesystem::path snapshot_dirpath(argv[1]);
+
+  try {
+    std::filesystem::directory_iterator dir(snapshot_dirpath);
+  } catch (const std::filesystem::filesystem_error& e) {
+    // Do not fail the test if the snapshots/data directory is not
+    // present
+    std::cout << "Snapshot directory does not exist" << std::endl;
+    return 0;
+  }
+
+  for (const auto& entry :
+       std::filesystem::directory_iterator(snapshot_dirpath)) {
+    std::cout << entry.path().filename() << std::endl;
+    SnapshotData data(entry.path());
+
+    data.runtests();
+  }
+}


### PR DESCRIPTION
test/snapshot.cpp compares the output of `fillsinks` to the known outputs in the TopoToolbox/snapshot_data repository. It is structured similarly to test/random_dem.cpp, with a class that handles loading all of the data and a `runtests` method that runs the libtopotoolbox functions and the comparisons.

This adds a test-time dependency on GDAL, which is used to read the snapshot data from disk. CMake is used to detect GDAL during compilation. If GDAL is not detected the snapshot tests are not compiled and will not be run by CTest.

The C++17 std::filesystem library is used for cross-platform filesystem access, so the supported C++ standard is incremented in CMakeLists.txt.

The TopoToolbox/snapshot_data repository is added as a submodule at test/snapshots. This repository only contains a README and a file with the SHA-256 checksums of all of the expected snapshot data. The data must be downloaded separately from the releases of that repository and extracted in `test/snapshots`.

If the test/snapshots/data repository is not present or the snapshot data have not been extracted there, the test will pass.

The snapshot tests are run on Ubuntu in CI. Installing GDAL on macOS and Windows is possible, but slow, so that task is left for future work.