### PR TITLE
Change links to topotoolbox3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ provide a user-friendly interface to the library and enable data
 import and export, visualization and interaction with the geospatial
 data analysis ecosystems of those languages.
 
-- [MATLAB](https://github.com/TopoToolbox/topotoolbox)
+- [MATLAB](https://github.com/TopoToolbox/topotoolbox3)
 - [Python](https://github.com/TopoToolbox/pytopotoolbox)
 
 ## Contributing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The :doc:`api` contains more information on the functions provided by libtopotoo
 
 Bindings for libtopotoolbox in higher-level programming languages provide a user-friendly interface to the library and enable data import and export, visualization and interaction with the geospatial data analysis ecosystems of those languages. Bindings are currently implemented for
 
-- `MATLAB <https://github.com/TopoToolbox/topotoolbox>`_
+- `MATLAB <https://github.com/TopoToolbox/topotoolbox3>`_
 - `Python <https://github.com/TopoToolbox/pytopotoolbox>`_
 
 Contributing


### PR DESCRIPTION
TopoToolbox/topotoolbox is the legacy TopoToolbox v2 repository TopoToolbox/topotoolbox3 is the new one with the libtopotoolbox bindings.