### PR TITLE
Invert test conditions and assertions in snapshot tests

### DIFF
--- a/test/snapshot.cpp
+++ b/test/snapshot.cpp
@@ -142,11 +142,11 @@ struct SnapshotData {
 
       for (ptrdiff_t j = 0; j < dims[1]; j++) {
         for (ptrdiff_t i = 0; i < dims[0]; i++) {
-          if (test_flats[j * dims[0] + i] & 1)
-            assert(flats[j * dims[0] + i] == 1);
+          if (flats[j * dims[0] + i] == 1)
+            assert(test_flats[j * dims[0] + i] & 1);
 
-          if (test_flats[j * dims[0] + i] & 2)
-            assert(sills[j * dims[0] + i] == 1);
+          if (sills[j * dims[0] + i] == 1)
+            assert(test_flats[j * dims[0] + i] & 2);
         }
       }
     }


### PR DESCRIPTION
This order ensures that we check every pixel that is identified as a flat or a sill in the snapshots. Previously if we never set any pixels in `test_flats`, the tests would still pass.