### PR TITLE
Implement cumtrapz

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -814,6 +814,66 @@ TOPOTOOLBOX_API
 void gradient8(float *output, float *dem, float cellsize, int use_mp,
                ptrdiff_t dims[2]);
 
+/**
+   @brief Integrate a `float` quantity over a stream network using
+   trapezoidal integration.
+
+   @param[out] integral The integrated output
+   @parblock
+   A pointer to a `float` array representing a node attribute list
+
+   If the stream network has N nodes, this array should have a length
+   N. This value must not be less than the largest value in either the
+   `source` or `target` arrays.
+   @endparblock
+
+   @param[in] integrand The quantity to be integrated
+   @parblock
+   A pointer to a `float` array representing a node attribute list
+
+   If the stream network has N nodes, this array should have a length
+   N. This value must not be less than the largest value in either the
+   `source` or `target` arrays.
+   @endparblock
+
+   @param[in] source The source node of each edge in the stream
+                     network
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The source nodes must be in topological order. The labels must
+   correspond to the 1-based indices of the nodes in the
+   node-attribute lists `integral` and `integrand`.
+   @endparblock
+
+   @param[in] target The target nodes of each edge in the stream
+                     network
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The labels must correspond to the 1-based indices of the nodes in
+   the node-attribute lists `integral` and `integrand`.
+   @endparblock
+
+   @param[in] weight The weight assigned to each edge in the stream network
+   @parblock
+   A pointer to a `float` array of size `edge_count`
+
+   For most applications of integration along the stream network, this
+   will be the geometric distance between the source and target pixels
+   in the desired units.
+   @endparblock
+
+   @param[in] edge_count The number of edges in the stream network
+ */
+TOPOTOOLBOX_API
+void cumtrapz_f32(float *integral, float *integrand, ptrdiff_t *source,
+                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count);
+
+TOPOTOOLBOX_API
+void cumtrapz_f64(double *integral, double *integrand, ptrdiff_t *source,
+                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count);
+
 /*
   Graphflood
 */

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -867,12 +867,14 @@ void gradient8(float *output, float *dem, float cellsize, int use_mp,
    @param[in] edge_count The number of edges in the stream network
  */
 TOPOTOOLBOX_API
-void cumtrapz_f32(float *integral, float *integrand, ptrdiff_t *source,
-                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count);
+void streamquad_trapz_f32(float *integral, float *integrand, ptrdiff_t *source,
+                          ptrdiff_t *target, float *weight,
+                          ptrdiff_t edge_count);
 
 TOPOTOOLBOX_API
-void cumtrapz_f64(double *integral, double *integrand, ptrdiff_t *source,
-                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count);
+void streamquad_trapz_f64(double *integral, double *integrand,
+                          ptrdiff_t *source, ptrdiff_t *target, float *weight,
+                          ptrdiff_t edge_count);
 
 /*
   Graphflood

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(topotoolbox
   graphflood/graphflood.c
   flow_routing.c
   flow_accumulation.c
-  cumtrapz.c
+  streamquad.c
 )
 
 # Define the include directory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(topotoolbox
   graphflood/graphflood.c
   flow_routing.c
   flow_accumulation.c
+  cumtrapz.c
 )
 
 # Define the include directory

--- a/src/cumtrapz.c
+++ b/src/cumtrapz.c
@@ -1,0 +1,32 @@
+#define TOPOTOOLBOX_BUILD
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "topotoolbox.h"
+
+TOPOTOOLBOX_API
+void cumtrapz_f32(float *integral, float *integrand, ptrdiff_t *source,
+                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count) {
+  // Iterate over the edges in reverse topological order (upstream)
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    // NOTE: source and target are 1-based indices into the node attribute
+    // list, so we must subtract 1 here
+    ptrdiff_t u = source[e] - 1;
+    ptrdiff_t v = target[e] - 1;
+    integral[u] = integral[v] + weight[e] * (integrand[u] + integrand[v]) / 2;
+  }
+}
+
+TOPOTOOLBOX_API
+void cumtrapz_f64(double *integral, double *integrand, ptrdiff_t *source,
+                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count) {
+  // Iterate over the edges in reverse topological order (upstream)
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    // NOTE: source and target are 1-based indices into the node attribute
+    // list, so we must subtract 1 here
+    ptrdiff_t u = source[e] - 1;
+    ptrdiff_t v = target[e] - 1;
+    integral[u] = integral[v] + weight[e] * (integrand[u] + integrand[v]) / 2;
+  }
+}

--- a/src/streamquad.c
+++ b/src/streamquad.c
@@ -6,8 +6,9 @@
 #include "topotoolbox.h"
 
 TOPOTOOLBOX_API
-void cumtrapz_f32(float *integral, float *integrand, ptrdiff_t *source,
-                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count) {
+void streamquad_trapz_f32(float *integral, float *integrand, ptrdiff_t *source,
+                          ptrdiff_t *target, float *weight,
+                          ptrdiff_t edge_count) {
   // Iterate over the edges in reverse topological order (upstream)
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
     // NOTE: source and target are 1-based indices into the node attribute
@@ -19,8 +20,9 @@ void cumtrapz_f32(float *integral, float *integrand, ptrdiff_t *source,
 }
 
 TOPOTOOLBOX_API
-void cumtrapz_f64(double *integral, double *integrand, ptrdiff_t *source,
-                  ptrdiff_t *target, float *weight, ptrdiff_t edge_count) {
+void streamquad_trapz_f64(double *integral, double *integrand,
+                          ptrdiff_t *source, ptrdiff_t *target, float *weight,
+                          ptrdiff_t edge_count) {
   // Iterate over the edges in reverse topological order (upstream)
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
     // NOTE: source and target are 1-based indices into the node attribute

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -7,6 +7,7 @@
 #include <ctime>
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Include topotoolbox.h in its own namespace to help prevent naming
@@ -400,8 +401,6 @@ int32_t test_routeflowd8_direction(uint8_t *direction, float *filled_dem,
 /*
   source should be a topological sort of the
   graph defined by direction.
-
-  This is O(N^2) and very slow.
  */
 int32_t test_routeflowd8_tsort(uint8_t *marks, ptrdiff_t *source,
                                uint8_t *direction, ptrdiff_t dims[2]) {
@@ -504,6 +503,37 @@ int32_t test_flow_routing_targets(ptrdiff_t *target, ptrdiff_t *source,
   return 0;
 }
 
+/*
+  Compute the upstream distance by computing shortest paths in the
+  flow network and compare them to the distances computed by cumtrapz
+  and recorded in node_distance.
+ */
+int32_t test_stream_distance(float *node_distance, ptrdiff_t *stream_grid,
+                             float *distance, ptrdiff_t *source,
+                             ptrdiff_t *target, float cellsize,
+                             ptrdiff_t dims[2]) {
+  for (ptrdiff_t edge = dims[0] * dims[1] - 1; edge >= 0; edge--) {
+    ptrdiff_t u = source[edge];
+    ptrdiff_t v = target[edge];
+    if (v >= 0) {
+      float w = labs(u - v) == 1 || labs(u - v) == dims[0] ? 1.0f : SQRT2f;
+      w *= cellsize;
+
+      distance[u] = distance[v] + w;
+    }
+  }
+
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t node = stream_grid[j * dims[0] + i];
+      if (node > 0) {
+        assert(node_distance[node - 1] == distance[j * dims[0] + i]);
+      }
+    }
+  }
+  return 0;
+}
+
 struct FlowRoutingData {
   std::array<ptrdiff_t, 2> dims;
   float cellsize;
@@ -547,6 +577,14 @@ struct FlowRoutingData {
   std::vector<float> accum;
   std::vector<float> accum2;
 
+  // stream network
+  std::vector<std::tuple<ptrdiff_t, ptrdiff_t, float>> stream_edges;
+  std::vector<ptrdiff_t> stream_source;
+  std::vector<ptrdiff_t> stream_target;
+  std::vector<float> stream_weight;
+  std::vector<ptrdiff_t> stream_grid;
+  ptrdiff_t stream_node_count;
+
   FlowRoutingData(ptrdiff_t input_dims[2], float cs, uint32_t seed)
       : dims({input_dims[0], input_dims[1]}),
         cellsize(cs),
@@ -569,7 +607,8 @@ struct FlowRoutingData {
         marks(dims[0] * dims[1]),
         target(dims[0] * dims[1]),
         accum(dims[0] * dims[1]),
-        accum2(dims[0] * dims[1]) {
+        accum2(dims[0] * dims[1]),
+        stream_grid(dims[0] * dims[1]) {
     // Initialize DEM, boundary conditions for fillsinks and fraction
     for (uint32_t col = 0; col < dims[1]; col++) {
       for (uint32_t row = 0; row < dims[0]; row++) {
@@ -651,6 +690,49 @@ struct FlowRoutingData {
     tt::gradient8(gradient_mp.data(), dem.data(), cellsize, 1, dims.data());
   }
 
+  void streamnetwork(float threshold) {
+    // Process the flow direction and accumulation data to create a
+    // stream network
+    ptrdiff_t node_index = 1;
+
+    for (ptrdiff_t e = (dims[0] * dims[1] - 1); e >= 0; e--) {
+      ptrdiff_t u = source[e];
+      ptrdiff_t v = target[e];
+
+      if (accum2[u] >= threshold) {
+        // Pixel u is in the stream network
+
+        // Map pixel u to the node index
+        stream_grid[u] = node_index++;
+
+        if (v >= 0) {
+          // u is not a sink/outlet
+
+          // Compute distance between source and target pixels.
+          // If the difference between u is 1 or dims[0], then they
+          // are 4 neighbors, otherwise they are 8 neighbors.
+          float w = labs(u - v) == 1 || labs(u - v) == dims[0]
+                        ? 1.0f * cellsize
+                        : SQRT2f * cellsize;
+
+          // Add (u,v) to the edge list
+          stream_edges.push_back(std::tuple(stream_grid[u], stream_grid[v], w));
+        }
+      }
+    }
+
+    // Fill the source and target vector by reversing stream_edges
+    stream_source.reserve(stream_edges.size());
+    stream_target.reserve(stream_edges.size());
+    for (auto e = stream_edges.rbegin(); e != stream_edges.rend(); e++) {
+      stream_source.push_back(std::get<0>(*e));
+      stream_target.push_back(std::get<1>(*e));
+      stream_weight.push_back(std::get<2>(*e));
+    }
+
+    stream_node_count = node_index - 1;
+  }
+
   void runtests(bool hybrid) {
     if (hybrid) {
       route_flow_hybrid();
@@ -692,6 +774,18 @@ struct FlowRoutingData {
 
     test_flow_accumulation_multimethod(accum.data(), accum2.data(),
                                        dims.data());
+
+    // Generate stream network
+    streamnetwork(dims[0] * dims[1] / 20.0f);
+
+    std::vector<float> integrand(stream_node_count, 1.0f);
+    std::vector<float> integral(stream_node_count, 0.0f);
+    std::vector<float> distance(dims[0] * dims[1], 0.0f);
+    tt::cumtrapz_f32(integral.data(), integrand.data(), stream_source.data(),
+                     stream_target.data(), stream_weight.data(),
+                     stream_source.size());
+    test_stream_distance(integral.data(), stream_grid.data(), distance.data(),
+                         source.data(), target.data(), cellsize, dims.data());
   }
 };
 

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -516,7 +516,7 @@ int32_t test_stream_distance(float *node_distance, ptrdiff_t *stream_grid,
     ptrdiff_t u = source[edge];
     ptrdiff_t v = target[edge];
     if (v >= 0) {
-      float w = labs(u - v) == 1 || labs(u - v) == dims[0] ? 1.0f : SQRT2f;
+      float w = llabs(u - v) == 1 || llabs(u - v) == dims[0] ? 1.0f : SQRT2f;
       w *= cellsize;
 
       distance[u] = distance[v] + w;
@@ -711,7 +711,7 @@ struct FlowRoutingData {
           // Compute distance between source and target pixels.
           // If the difference between u is 1 or dims[0], then they
           // are 4 neighbors, otherwise they are 8 neighbors.
-          float w = labs(u - v) == 1 || labs(u - v) == dims[0]
+          float w = llabs(u - v) == 1 || llabs(u - v) == dims[0]
                         ? 1.0f * cellsize
                         : SQRT2f * cellsize;
 

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -505,7 +505,7 @@ int32_t test_flow_routing_targets(ptrdiff_t *target, ptrdiff_t *source,
 
 /*
   Compute the upstream distance by computing shortest paths in the
-  flow network and compare them to the distances computed by cumtrapz
+  flow network and compare them to the distances computed by streamquad_trapz
   and recorded in node_distance.
  */
 int32_t test_stream_distance(float *node_distance, ptrdiff_t *stream_grid,
@@ -781,9 +781,9 @@ struct FlowRoutingData {
     std::vector<float> integrand(stream_node_count, 1.0f);
     std::vector<float> integral(stream_node_count, 0.0f);
     std::vector<float> distance(dims[0] * dims[1], 0.0f);
-    tt::cumtrapz_f32(integral.data(), integrand.data(), stream_source.data(),
-                     stream_target.data(), stream_weight.data(),
-                     stream_source.size());
+    tt::streamquad_trapz_f32(integral.data(), integrand.data(),
+                             stream_source.data(), stream_target.data(),
+                             stream_weight.data(), stream_source.size());
     test_stream_distance(integral.data(), stream_grid.data(), distance.data(),
                          source.data(), target.data(), cellsize, dims.data());
   }


### PR DESCRIPTION
Resolves #144

include/topotoolbox.h adds interfaces for two variants of cumtrapz for different data types and documents `cumtrapz_f32`.

src/cumtrapz.c adds implementation for the two variants. These are identical to each other except for the data type of the `integral` and `integrand` arguments.

src/CMakeLists.txt adds src/cumtrapz.c to the build system.

test/random_dem.cpp tests cumtrapz by computing the along stream distance using cumtrapz and by explicitly tracing the flow network. First it generates the stream network edge list by thresholding the flow accumulation. Then it runs cumtrapz with a unit integrand. `test_stream_distance` computes the downstream distance for every pixel in the DEM by iterating over the flow network edges computed by `flow_routing_d8_carve` and then compares this with the cumtrapz solution. This is not the most severe test because the two computations are essentially identical, they just iterate over different subsets of the flow network. However, cumtrapz is otherwise rather challenging to test analytically.