### PR TITLE
Fix tweight to 1 in `gwdt_computecosts`

### DIFF
--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -254,11 +254,12 @@ void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
       float current_depth =
           filled_dem[current_pixel] - original_dem[current_pixel];
 
-      float tweight = 2.0f;
+      // If tweight is fixed to one, we do not need to apply the power.
+      // costs[current_pixel] - current_depth should always be positive
+      // float tweight = 1.0f;
       float CarveMinVal = 0.1f;
 
-      costs[current_pixel] =
-          powf(costs[current_pixel] - current_depth, tweight) + CarveMinVal;
+      costs[current_pixel] = costs[current_pixel] - current_depth + CarveMinVal;
     }
   }
 }


### PR DESCRIPTION
Resolves #146

This change is documented by a comment in gwdt.c, and the tweight definition is left commented out, in case it needs to be replaced in the future.