### PR TITLE
Output snapshot artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,12 @@ jobs:
         run: cmake --build ${{github.workspace}}/build/debug --config Debug
       - name: Test
         run: ctest --test-dir ${{github.workspace}}/build/debug -C Debug --output-on-failure
+      - name: Upload test snapshot artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot_test_output
+          path: ${{github.workspace}}/build/debug/test/snapshots/
   release-build:
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Continues work on #150

.github.workflows/ci.yaml adds an upload-artifact step to the debug build. This step save the output of the snapshot tests as an artifact and makes it available for download. The original snapshot data as well as output data from any failed test will be saved.