### PR TITLE
Compute gradient8 as the steepest downward gradient

### DIFF
--- a/src/gradient8.c
+++ b/src/gradient8.c
@@ -60,8 +60,8 @@ void gradient8(float *output, float *dem, float cellsize, int use_mp,
           } else {
             horizontal_dist = cellsize;
           }
-          vertical_dist = fabsf(dem[neighbour_j * dims[0] + neighbour_i] -
-                                dem[j * dims[0] + i]);
+          vertical_dist =
+              dem[j * dims[0] + i] - dem[neighbour_j * dims[0] + neighbour_i];
 
           // compute gradient and check if it's the max gradient
           local_gradient = vertical_dist / horizontal_dist;


### PR DESCRIPTION
gradient8 as computed by TopoToolbox 2 and described in O'Callaghan and Mark (1984) computes the steepest downward gradient, not the steepest absolute gradient. This commit makes that change in src/gradient8.c and reconfigures the random_dem test in test/random_dem.cpp to test the property that the computed gradient is greater than or equal to the gradients between the central pixel and its nearest neighbors.

@Teschl: while looking at some examples, I noticed that we implemented this incorrectly the first time around. It is an easy fix though. I am pretty sure we don't rely on this behavior in pytopotoolbox or anywhere else, but let me know if you notice anything breaking as a result.