### PR TITLE
Add a Makefile for use by R

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,14 @@
+.POSIX:
+.SUFFIXES:
+
+SRCS=excesstopography.c fillsinks.c flow_accumulation.c flow_routing.c gradient8.c gwdt.c identifyflats.c morphology/reconstruct.c priority_queue.c topotoolbox.c graphflood/gf_utils.c graphflood/sfgraph.c graphflood/priority_flood_standalone.c graphflood/gf_flowacc.c graphflood/graphflood.c
+
+OBJS=$(SRCS:.c=.o)
+
+libtopotoolbox.a: $(OBJS)
+	$(AR) $(ARFLAGS) libtopotoolbox.a $(OBJS)
+	rm -f $(OBJS)
+
+.SUFFIXES: .c .o
+.c.o:
+	$(CC) $(CFLAGS) -DTOPOTOOLBOX_STATICLIB -I../include -c -o $@ $<

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 .SUFFIXES:
 
-SRCS=excesstopography.c fillsinks.c flow_accumulation.c flow_routing.c gradient8.c gwdt.c identifyflats.c morphology/reconstruct.c priority_queue.c topotoolbox.c graphflood/gf_utils.c graphflood/sfgraph.c graphflood/priority_flood_standalone.c graphflood/gf_flowacc.c graphflood/graphflood.c
+SRCS=excesstopography.c fillsinks.c flow_accumulation.c flow_routing.c gradient8.c gwdt.c identifyflats.c morphology/reconstruct.c priority_queue.c streamquad.c topotoolbox.c graphflood/gf_utils.c graphflood/sfgraph.c graphflood/priority_flood_standalone.c graphflood/gf_flowacc.c graphflood/graphflood.c
 
 OBJS=$(SRCS:.c=.o)
 


### PR DESCRIPTION
R package compilation process requires a Makefile, and it cannot use our more complex CMake build system. This Makefile compiles a static library version of libtopotoolbox out of all of the source files in `src/`. It should generally not be used to compile libtopotoolbox because it is not portable to other operating systems.