### PR TITLE
Change CarveMinVal to a double

### DIFF
--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -262,7 +262,8 @@ void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
       // MATLAB implementation.
       double CarveMinVal = 0.1;
 
-      costs[current_pixel] = costs[current_pixel] - current_depth + CarveMinVal;
+      costs[current_pixel] =
+          (float)(costs[current_pixel] - current_depth + CarveMinVal);
     }
   }
 }

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -259,7 +259,16 @@ void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
       // float tweight = 1.0f;
 
       // CarveMinVal is a double to maintain consistency with the
-      // MATLAB implementation.
+      // MATLAB implementation. The right hand side is of the cost
+      // computation below is performed in double precision and
+      // rounded back to single precision to store in the `costs`
+      // array. The magnitude of rounding error when CarveMinVal is a
+      // float depends on the values of costs, current_depth and
+      // CarveMinVal and is not always intuitive. If CarveMinVal can
+      // be exactly represented as a single precision float, then the
+      // results do not depend on whether it is a single or a
+      // double. Using a double CarveMinVal does have a minor
+      // performance cost.
       double CarveMinVal = 0.1;
 
       costs[current_pixel] =

--- a/src/gwdt.c
+++ b/src/gwdt.c
@@ -257,7 +257,10 @@ void gwdt_computecosts(float *costs, ptrdiff_t *conncomps, int32_t *flats,
       // If tweight is fixed to one, we do not need to apply the power.
       // costs[current_pixel] - current_depth should always be positive
       // float tweight = 1.0f;
-      float CarveMinVal = 0.1f;
+
+      // CarveMinVal is a double to maintain consistency with the
+      // MATLAB implementation.
+      double CarveMinVal = 0.1;
 
       costs[current_pixel] = costs[current_pixel] - current_depth + CarveMinVal;
     }


### PR DESCRIPTION
MATLAB's implementation of `gwdt_computecosts` uses a double precision floating point value for `CarveMinVal` even when the costs arrays are `float`. This results in subtle numerical differences between the libtopotoolbox implementation and the MATLAB implementation. This changes libtopotoolbox so that it matches the MATLAB implementation.

This change should be more or less inconsequential from the scientific perspective. I do not believe, for example, that it is responsible for the discrepancies noted in #122, though that hypothesis remains to be confirmed. The change is made only to avoid unnecessary discrepancies between the two implementations so that issues like #122 are easier to resolve.

There is a very slight performance cost to using a `double` rather than a `float` here. However, MATLAB must also deal with the same performance cost, and it is not the bottleneck in `gwdt_computecosts`.

When `CarveMinVal` is a double, the intermediate computation is promoted to double precision, and the result is rounded to single precision to be stored in the `costs` array. This is not identical to the same computation performed entirely in single precision arithmetic, and this causes the numerical differences observed between C and MATLAB.

The problem is exacerbated because the constant 0.1 cannot be represented exactly as a binary floating point number, so it must be rounded. Indeed, it seems like using a constant that can be represented exactly in both precisions (such as 0.125) gets rid of these numerical differences because no rounding is necessary. One could use `float CarveMinVal = 0.125f` here and `CarveMinVal = 0.125` in MATLAB, and one will generally obtain the same answers. However, this seems like a fragile solution as any future changes to this constant must be aware of the differences in its floating point representation.

An alternative solution is to change the constant in MATLAB so that it is the same precision as the other arrays in this expression via something like `CarveMinVal = cast(0.1,'like',D)`. The difference between this change and the current commit is mostly a matter of choice. I have chosen to make the change in libtopotoolbox to avoid changing observable behavior in the MATLAB implementation unnecessarily.