### PR TITLE
Use GDALDataset::Create rather than GDALDataset::CreateCopy

### DIFF
--- a/test/snapshot.cpp
+++ b/test/snapshot.cpp
@@ -49,8 +49,15 @@ void write_data_to_file(const std::string& dst_filename,
 
   GDALDriver* driver = src_ds->GetDriver();
   GDALDataset* dst_ds =
-      driver->CreateCopy(dst_filename.data(), src_ds, FALSE, NULL, NULL, NULL);
+      driver->Create(dst_filename.data(), dims[0], dims[1], 1, S, NULL);
   assert(dst_ds);
+
+  const OGRSpatialReference* ref = src_ds->GetSpatialRef();
+  assert(dst_ds->SetSpatialRef(ref) == CE_None);
+
+  double gt[6];
+  assert(src_ds->GetGeoTransform(gt) == CE_None);
+  assert(dst_ds->SetGeoTransform(gt) == CE_None);
 
   GDALRasterBand* poBand = dst_ds->GetRasterBand(1);
   assert(poBand->RasterIO(GF_Write, 0, 0, dims[0], dims[1], output.data(),


### PR DESCRIPTION
We use GDAL to save the snapshots for diagnostic purposes. GDALDataset::CreateCopy copies all of the metadata from the source data set including the data type. In the case when the output data has a different data type from the source dataset, the data are converted to the type of the source dataset. This works for the existing snapshot tests, but it does not allow us to save auxiliary data unless they have the same type as an available source data set.

This change does not affect the test suite itself.