### PR TITLE
Do not assign drainage basins to invalid pixels

### DIFF
--- a/src/drainagebasins.c
+++ b/src/drainagebasins.c
@@ -13,18 +13,24 @@ void drainagebasins(ptrdiff_t *basins, ptrdiff_t *source, ptrdiff_t *target,
   }
 
   ptrdiff_t basin_count = 1;  // Start the basin labels at one.
-  for (ptrdiff_t j = dims[1] - 1; j >= 0; j--) {
-    for (ptrdiff_t i = dims[0] - 1; i >= 0; i--) {
-      ptrdiff_t src = source[j * dims[0] + i];
-      ptrdiff_t tgt = target[j * dims[0] + i];
 
-      if (tgt < 0) {
-        // src has no downstream neighbors and is the root of the
-        // drainage basin tree
-        basins[src] = basin_count++;
-      } else {
-        basins[src] = basins[tgt];
-      }
+  ptrdiff_t edge_count = dims[0] * dims[1];
+
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t src = source[e];
+    ptrdiff_t tgt = target[e];
+
+    if (tgt < 0) {
+      // src is an outlet
+      //
+      // Don't initialize the basin here: we are refactoring to get
+      // rid of these placeholder edges
+      continue;
     }
+    if (basins[tgt] == 0) {
+      // If tgt does not yet belong to a drainage basin, create a new one
+      basins[tgt] = basin_count++;
+    }
+    basins[src] = basins[tgt];
   }
 }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -535,19 +535,18 @@ int32_t test_stream_distance(float *node_distance, ptrdiff_t *stream_grid,
  */
 int32_t test_drainagebasins(ptrdiff_t *basins, ptrdiff_t *source,
                             ptrdiff_t *target, ptrdiff_t dims[2]) {
-  for (ptrdiff_t j = 0; j < dims[1]; j++) {
-    for (ptrdiff_t i = 0; i < dims[0]; i++) {
-      ptrdiff_t src = source[j * dims[0] + i];
-      ptrdiff_t tgt = target[j * dims[0] + i];
+  ptrdiff_t edge_count = dims[0] * dims[1];
+  for (ptrdiff_t e = 0; e < edge_count; e++) {
+    ptrdiff_t src = source[e];
+    ptrdiff_t tgt = target[e];
 
-      assert(src < dims[0] * dims[1]);
-      assert(src >= 0);
-      assert(tgt < dims[0] * dims[1]);
-      if (tgt >= 0) {
-        // Only check connectivity if source has a downstream neighbor
-        assert(basins[src] == basins[tgt]);
-        assert(basins[src] > 0);
-      }
+    assert(src < dims[0] * dims[1]);
+    assert(src >= 0);
+    assert(tgt < dims[0] * dims[1]);
+    if (tgt >= 0) {
+      // Only check connectivity if source has a downstream neighbor
+      assert(basins[src] == basins[tgt]);
+      assert(basins[src] > 0);
     }
   }
   return 0;


### PR DESCRIPTION
This PR fixes a problem with drainage basins which would lead to pixels that are not part of the flow network such as NaNs in the DEM being assigned to their own drainage basin.

The problem was that sinks, outlets and invalid pixels are all assigned placeholder edges by `flow_routing_d8_carve` that point from them to -1. We were using this placeholder edge to detect when to create a new drainage basin. This works for the sinks and outlets, but also creates a drainage basin for the invalid pixels. This PR switches this behavior to 1. skip these placeholder edges and 2. test whether the target pixel has not yet been assigned to a drainage basin. This matches the behavior of the MATLAB implementation, leaving invalid pixels with a 0 label for their drainage basin.

This is part of some changes I am planning to the representation of flow networks in libtopotoolbox that should eventually remove those placeholder edges.