### PR TITLE
Switch stream traversal functions to use 0-based arrays

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -842,7 +842,7 @@ void gradient8(float *output, float *dem, float cellsize, int use_mp,
    A pointer to a `ptrdiff_t` array of size `edge_count`
 
    The source nodes must be in topological order. The labels must
-   correspond to the 1-based indices of the nodes in the
+   correspond to the 0-based indices of the nodes in the
    node-attribute lists `integral` and `integrand`.
    @endparblock
 
@@ -851,7 +851,7 @@ void gradient8(float *output, float *dem, float cellsize, int use_mp,
    @parblock
    A pointer to a `ptrdiff_t` array of size `edge_count`
 
-   The labels must correspond to the 1-based indices of the nodes in
+   The labels must correspond to the 0-based indices of the nodes in
    the node-attribute lists `integral` and `integrand`.
    @endparblock
 
@@ -909,7 +909,7 @@ void streamquad_trapz_f64(double *integral, double *integrand,
    A pointer to a `ptrdiff_t` array of size `edge_count`
 
    The source nodes must be in topological order. The labels must
-   correspond to the 1-based indices of the nodes in the
+   correspond to the 0-based indices of the nodes in the
    node-attribute lists `integral` and `integrand`.
    @endparblock
 
@@ -918,7 +918,7 @@ void streamquad_trapz_f64(double *integral, double *integrand,
    @parblock
    A pointer to a `ptrdiff_t` array of size `edge_count`
 
-   The labels must correspond to the 1-based indices of the nodes in
+   The labels must correspond to the 0-based indices of the nodes in
    the node-attribute lists `integral` and `integrand`.
    @endparblock
 
@@ -964,7 +964,7 @@ void traverse_up_u32_and(uint32_t *output, uint32_t *input, ptrdiff_t *source,
    A pointer to a `ptrdiff_t` array of size `edge_count`
 
    The source nodes must be in topological order. The labels must
-   correspond to the 1-based indices of the nodes in the
+   correspond to the 0-based indices of the nodes in the
    node-attribute lists `integral` and `integrand`.
    @endparblock
 
@@ -973,7 +973,7 @@ void traverse_up_u32_and(uint32_t *output, uint32_t *input, ptrdiff_t *source,
    @parblock
    A pointer to a `ptrdiff_t` array of size `edge_count`
 
-   The labels must correspond to the 1-based indices of the nodes in
+   The labels must correspond to the 0-based indices of the nodes in
    the node-attribute lists `integral` and `integrand`.
    @endparblock
 

--- a/src/streamquad.c
+++ b/src/streamquad.c
@@ -14,8 +14,8 @@ void streamquad_trapz_f32(float *integral, float *integrand, ptrdiff_t *source,
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
     // NOTE: source and target are 1-based indices into the node attribute
     // list, so we must subtract 1 here
-    ptrdiff_t u = source[e] - 1;
-    ptrdiff_t v = target[e] - 1;
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
     integral[u] = integral[v] + weight[e] * (integrand[u] + integrand[v]) / 2;
   }
 }
@@ -28,8 +28,8 @@ void streamquad_trapz_f64(double *integral, double *integrand,
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
     // NOTE: source and target are 1-based indices into the node attribute
     // list, so we must subtract 1 here
-    ptrdiff_t u = source[e] - 1;
-    ptrdiff_t v = target[e] - 1;
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
     integral[u] = integral[v] + weight[e] * (integrand[u] + integrand[v]) / 2;
   }
 }
@@ -38,8 +38,8 @@ TOPOTOOLBOX_API
 void traverse_up_u32_and(uint32_t *output, uint32_t *input, ptrdiff_t *source,
                          ptrdiff_t *target, ptrdiff_t edge_count) {
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
-    ptrdiff_t u = source[e] - 1;
-    ptrdiff_t v = target[e] - 1;
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
 
     output[u] = output[v] & input[u];
   }
@@ -49,8 +49,8 @@ TOPOTOOLBOX_API
 void traverse_down_f32_max_add(float *output, float *input, ptrdiff_t *source,
                                ptrdiff_t *target, ptrdiff_t edge_count) {
   for (ptrdiff_t e = 0; e < edge_count; e++) {
-    ptrdiff_t u = source[e] - 1;
-    ptrdiff_t v = target[e] - 1;
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
 
     output[v] = fmaxf(output[v], output[u] + input[e]);
   }


### PR DESCRIPTION
This unifies the stream network traversal interface with the flow network. I would like it to be possible to pass source and target arrays from either a FLOWobj/FlowObject or a STREAMobj/StreamObject to our various traversal functions without needing to worry about which indexing convention is used. 0-based arrays make the most sense for C, so we'll assume that source and target are 0-based indices and decrement in MATLAB.

As mentioned in #164. This will require changes in pytopotoolbox, but these functions are not yet used in MATLAB.