### PR TITLE
Add edge_count argument to drainagebasins

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1155,12 +1155,17 @@ void graphflood_full(GF_FLOAT *Z, GF_FLOAT *hw, uint8_t *BCs,
 
    @param[out] source The source pixel for each edge
    @parblock
-   A pointer to a `ptrdiff_t` array of size `dims[0]` x `dims[1]`
+   A pointer to a `ptrdiff_t` array of size `edge_count`
    @endparblock
 
    @param[in] target The target pixel for each edge
    @parblock
-   A pointer to a `ptrdiff_t` array of size `dims[0]` x `dims[1]`
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+   @endparblock
+
+   @param[in] edge_count The number of edges in the flow network
+   @parblock
+   A ptrdiff_t representing the length of the `source` and `target` arrays
    @endparblock
 
    @param[in] dims The dimensions of the arrays
@@ -1173,6 +1178,6 @@ void graphflood_full(GF_FLOAT *Z, GF_FLOAT *hw, uint8_t *BCs,
  */
 TOPOTOOLBOX_API
 void drainagebasins(ptrdiff_t *basins, ptrdiff_t *source, ptrdiff_t *target,
-                    ptrdiff_t dims[2]);
+                    ptrdiff_t edge_count, ptrdiff_t dims[2]);
 
 #endif  // TOPOTOOLBOX_H

--- a/src/drainagebasins.c
+++ b/src/drainagebasins.c
@@ -4,7 +4,7 @@
 
 TOPOTOOLBOX_API
 void drainagebasins(ptrdiff_t *basins, ptrdiff_t *source, ptrdiff_t *target,
-                    ptrdiff_t dims[2]) {
+                    ptrdiff_t edge_count, ptrdiff_t dims[2]) {
   // Initialize the basins array
   for (ptrdiff_t j = 0; j < dims[1]; j++) {
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
@@ -13,8 +13,6 @@ void drainagebasins(ptrdiff_t *basins, ptrdiff_t *source, ptrdiff_t *target,
   }
 
   ptrdiff_t basin_count = 1;  // Start the basin labels at one.
-
-  ptrdiff_t edge_count = dims[0] * dims[1];
 
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
     ptrdiff_t src = source[e];

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -752,7 +752,7 @@ struct FlowRoutingData {
   void drainagebasins() {
     ProfileFunction(prof);
 
-    tt::drainagebasins(basins.data(), source.data(), target.data(),
+    tt::drainagebasins(basins.data(), source.data(), target.data(), edge_count,
                        dims.data());
   }
 


### PR DESCRIPTION
With the new flow routing edge lists (TopoToolbox/libtopotoolbox#167), we can no longer guarantee that `source` and `target` are of length `dims[0]*dims[1]`, and we to know need the explicit number of edges in the edge list.