### PR TITLE
Implement traverse_f32_add_mul

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -993,6 +993,60 @@ void traverse_down_f32_max_add(float *output, float *input, ptrdiff_t *source,
                                ptrdiff_t *target, ptrdiff_t edge_count);
 
 /**
+   @brief Downstream traversal with multiply-add
+
+   Accumulates the edge weights in the `input` edge attribute list
+   using a multiply-add update:
+
+   for (e = (u,v)) in edges:
+     output[v] = output[v] + output[u] * input[e];
+
+   With input giving the flow fraction of each edge and output
+   initialized to ones, this will compute the flow accumulation.
+
+   @param[out] output The accumulated output
+   @parblock
+   A pointer to a `float` array representing a node attribute list
+
+   If the stream network has N nodes, this array should have a length
+   N. This value must not be less than the largest value in either the
+   `source` or `target` arrays.
+   @endparblock
+
+   @param[in] input The edge weights
+   @parblock
+   A pointer to a `float` array representing a edge attribute list
+
+   If the stream network has edge_count edges, this array should have a length
+   edge_count.
+   @endparblock
+
+   @param[in] source The source node of each edge in the stream
+                     network
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The source nodes must be in topological order. The labels must
+   correspond to the 0-based indices of the nodes in the
+   node-attribute lists `integral` and `integrand`.
+   @endparblock
+
+   @param[in] target The target nodes of each edge in the stream
+                     network
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The labels must correspond to the 0-based indices of the nodes in
+   the node-attribute lists `integral` and `integrand`.
+   @endparblock
+
+   @param[in] edge_count The number of edges in the stream network
+ */
+TOPOTOOLBOX_API
+void traverse_down_f32_add_mul(float *output, float *input, ptrdiff_t *source,
+                               ptrdiff_t *target, ptrdiff_t edge_count);
+
+/**
    @brief Compute the in- and outdegrees of each node in a graph
 
    @param[out] indegree The indegree of each node in the stream network

--- a/src/streamquad.c
+++ b/src/streamquad.c
@@ -57,6 +57,17 @@ void traverse_down_f32_max_add(float *output, float *input, ptrdiff_t *source,
 }
 
 TOPOTOOLBOX_API
+void traverse_down_f32_add_mul(float *output, float *input, ptrdiff_t *source,
+                               ptrdiff_t *target, ptrdiff_t edge_count) {
+  for (ptrdiff_t e = 0; e < edge_count; e++) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = source[e];
+
+    output[v] = output[v] + output[u] * input[e];
+  }
+}
+
+TOPOTOOLBOX_API
 void edgelist_degree(uint8_t *indegree, uint8_t *outdegree, ptrdiff_t *source,
                      ptrdiff_t *target, ptrdiff_t node_count,
                      ptrdiff_t edge_count) {


### PR DESCRIPTION
This could be used to replace the more specific
`flow_accumulation_edgelist` implementation for flow networks, but it can also be used to compute the size of connected components of the stream network.

See the discussion in #164 