### PR TITLE
Implement propagatevaluesupstream

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1094,6 +1094,118 @@ void edgelist_degree(uint8_t *indegree, uint8_t *outdegree, ptrdiff_t *source,
                      ptrdiff_t *target, ptrdiff_t node_count,
                      ptrdiff_t edge_count);
 
+/**
+   @brief Propagate `float` values upstream
+
+   The values in the `data` node attribute list are copied to their
+   upstream neighbors according to the edges contained in the `source`
+   and `target` arrays.
+
+   Nodes with no downstream neighbors should be initialized in the
+   `data` array with the values to be propagated upstream. The
+   upstream values will be overwritten.
+
+   @param[in, out] data The data array
+   @parblock
+   A pointer to an array of the desired type representing a node attribute list.
+
+   This must be at least as large as the largest index in either the
+   `source` or `target` arrays.
+   @endparblock
+
+   @param[in] source The source node of each edge in the stream
+                     network
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The source nodes must be in topological order. The labels must
+   correspond to the 0-based indices of the nodes in the
+   node-attribute list `data`.
+   @endparblock
+
+   @param[in] target The target nodes of each edge in the stream
+                     network
+   @parblock
+   A pointer to a `ptrdiff_t` array of size `edge_count`
+
+   The labels must correspond to the 0-based indices of the nodes in
+   the node-attribute list `data`
+   @endparblock
+
+   @param[in] edge_count The number of edges in the stream network
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_f32(float *data, ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `double` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_f64(double *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `uint8_t` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_u8(uint8_t *data,
+                                                ptrdiff_t *source,
+                                                ptrdiff_t *target,
+                                                ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `uint32_t` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_u32(uint32_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `uint64_t` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_u64(uint64_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `int8_t` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_i8(int8_t *data, ptrdiff_t *source,
+                                                ptrdiff_t *target,
+                                                ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `int32_t` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_i32(int32_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count);
+
+/**
+   @brief Propagate `int64_t` values upstream
+
+   @copydetails propagatevaluesupstream_f32()
+ */
+TOPOTOOLBOX_API void propagatevaluesupstream_i64(int64_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count);
 /*
   Graphflood
 */

--- a/src/streamquad.c
+++ b/src/streamquad.c
@@ -84,3 +84,109 @@ void edgelist_degree(uint8_t *indegree, uint8_t *outdegree, ptrdiff_t *source,
     outdegree[u]++;
   }
 }
+
+/*
+  propagatevaluesupstream is implemented identically for several
+  different input data types. While it is possible to reduce this
+  duplication using a macro, the various interfaces still need to be
+  exposed to downstream users of the library.
+
+  The following input data types are implemented
+
+  float:    propagatevaluesupstream_f32
+  double:   propagatevaluesupstream_f64
+  uint8_t:  propagatevaluesupstream_u8
+  uint32_t: propagatevaluesupstream_u32
+  uint64_t: propagatevaluesupstream_u64
+  int8_t:   propagatevaluesupstream_u8
+  int32_t:  propagatevaluesupstream_u32
+  int64_t:  propagatevaluesupstream_u64
+
+  Others can be added as needed.
+ */
+
+TOPOTOOLBOX_API void propagatevaluesupstream_f32(float *data, ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_f64(double *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_u8(uint8_t *data,
+                                                ptrdiff_t *source,
+                                                ptrdiff_t *target,
+                                                ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_u32(uint32_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_u64(uint64_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_i8(int8_t *data, ptrdiff_t *source,
+                                                ptrdiff_t *target,
+                                                ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_i32(int32_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}
+
+TOPOTOOLBOX_API void propagatevaluesupstream_i64(int64_t *data,
+                                                 ptrdiff_t *source,
+                                                 ptrdiff_t *target,
+                                                 ptrdiff_t edge_count) {
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+    data[u] = data[v];
+  }
+}

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -546,6 +546,18 @@ int32_t test_drainagebasins(ptrdiff_t *basins, ptrdiff_t *source,
   return 0;
 }
 
+int32_t test_propagatevalues(float *pvF32, double *pvF64, uint8_t *pvU8,
+                             uint32_t *pvU32, uint64_t *pvU64, int8_t *pvI8,
+                             int32_t *pvI32, int64_t *pvI64,
+                             ptrdiff_t node_count) {
+  for (ptrdiff_t v = 0; v < node_count; v++) {
+    assert(pvF32[v] == pvF64[v] && pvF64[v] == pvU8[v] && pvU32[v] == pvU8[v] &&
+           pvU64[v] == pvU32[v] && (uint64_t)pvI8[v] == pvU64[v] &&
+           pvI32[v] == pvI8[v] && pvI64[v] == pvI32[v]);
+  }
+  return 0;
+}
+
 struct FlowRoutingData {
   std::array<ptrdiff_t, 2> dims;
   float cellsize;
@@ -815,6 +827,46 @@ struct FlowRoutingData {
     test_stream_distance(integral.data(), stream_grid.data(), distance.data(),
                          source.data(), target.data(), cellsize, source.size(),
                          dims.data());
+
+    std::vector<float> pvF32(stream_node_count, 0.0f);
+    std::vector<double> pvF64(stream_node_count, 0.0);
+    std::vector<uint8_t> pvU8(stream_node_count, 0);
+    std::vector<uint32_t> pvU32(stream_node_count, 0);
+    std::vector<uint64_t> pvU64(stream_node_count, 0);
+    std::vector<int8_t> pvI8(stream_node_count, 0);
+    std::vector<int32_t> pvI32(stream_node_count, 0);
+    std::vector<int64_t> pvI64(stream_node_count, 0);
+
+    for (uint64_t i = 0; i < (uint64_t)stream_node_count; i++) {
+      pvF32[i] = i & 0x7f;
+      pvF64[i] = i & 0x7f;
+      pvU8[i] = i & 0x7f;
+      pvU32[i] = i & 0x7f;
+      pvU64[i] = i & 0x7f;
+      pvI8[i] = i & 0x7f;
+      pvI32[i] = i & 0x7f;
+      pvI64[i] = i & 0x7f;
+    }
+
+    tt::propagatevaluesupstream_f32(pvF32.data(), stream_source.data(),
+                                    stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_f64(pvF64.data(), stream_source.data(),
+                                    stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_u8(pvU8.data(), stream_source.data(),
+                                   stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_u32(pvU32.data(), stream_source.data(),
+                                    stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_u64(pvU64.data(), stream_source.data(),
+                                    stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_i8(pvI8.data(), stream_source.data(),
+                                   stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_i32(pvI32.data(), stream_source.data(),
+                                    stream_target.data(), stream_source.size());
+    tt::propagatevaluesupstream_i64(pvI64.data(), stream_source.data(),
+                                    stream_target.data(), stream_source.size());
+    test_propagatevalues(pvF32.data(), pvF64.data(), pvU8.data(), pvU32.data(),
+                         pvU64.data(), pvI8.data(), pvI32.data(), pvI64.data(),
+                         stream_node_count);
   }
 };
 

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -837,15 +837,16 @@ struct FlowRoutingData {
     std::vector<int32_t> pvI32(stream_node_count, 0);
     std::vector<int64_t> pvI64(stream_node_count, 0);
 
-    for (uint64_t i = 0; i < (uint64_t)stream_node_count; i++) {
-      pvF32[i] = i & 0x7f;
-      pvF64[i] = i & 0x7f;
-      pvU8[i] = i & 0x7f;
-      pvU32[i] = i & 0x7f;
-      pvU64[i] = i & 0x7f;
-      pvI8[i] = i & 0x7f;
-      pvI32[i] = i & 0x7f;
-      pvI64[i] = i & 0x7f;
+    for (ptrdiff_t i = 0; i < stream_node_count; i++) {
+      uint8_t v = (uint64_t)i & 0x7f;
+      pvF32[i] = v;
+      pvF64[i] = v;
+      pvU8[i] = v;
+      pvU32[i] = v;
+      pvU64[i] = v;
+      pvI8[i] = v;
+      pvI32[i] = v;
+      pvI64[i] = v;
     }
 
     tt::propagatevaluesupstream_f32(pvF32.data(), stream_source.data(),


### PR DESCRIPTION
There are many variants called `propagatevaluesupstream_*` for different input data types. This does duplicate the bodies of these functions, but I am not sure whether the
alternatives (e.g. metaprogramming, pointer casting) are necessarily more maintainable.

A test is added to test/random_dem.cpp to ensure that every propagatevaluesupstream version provides the same answer. This should help make sure that any future changes to
propagatevaluesupstream, such as supporting fill values, are properly duplicated across the different implementations.