### PR TITLE
Download snapshot data using FetchContent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  snapshot_version: v1.5.0
+
 on:
   pull_request:
     branches: ["main"]
@@ -18,8 +21,6 @@ jobs:
           clang-format-version: '14'
   debug-build:
     runs-on: ubuntu-latest
-    env:
-      snapshot_version: v1.5.0
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,21 +36,12 @@ jobs:
       - name: Install Python build dependencies
         run: |
           pip install -r ${{github.workspace}}/docs/requirements.txt
-      - name: Cache snapshot data
-        id: cache-snapshots-debug
-        uses: actions/cache@v4
+      - name: Restore snapshot data cache
+        id: restore-cache-snapshots-debug
+        uses: actions/cache/restore@v4
         with:
           path: test/snapshots
           key: snapshots-${{ env.snapshot_version }}
-      - name: Download and extract snapshot data
-        if: steps.cache-snapshots-debug.outputs.cache-hit != 'true'
-        working-directory: test/snapshots
-        shell: bash
-        run: |
-          curl -L -o snapshot_data.tar.gz \
-          "https://github.com/TopoToolbox/snapshot_data/releases/download/$snapshot_version/snapshot_data.tar.gz"
-          tar -xzf snapshot_data.tar.gz
-          shasum -c --status sha256sum.txt
       - name: Configure
         run: >
           cmake -B ${{github.workspace}}/build/debug
@@ -60,6 +52,14 @@ jobs:
           -DBUILD_SHARED_LIBS=OFF
           -DTT_SANITIZE=ON
           -DTT_BUILD_DOCS=ON
+          -DTT_DOWNLOAD_SNAPSHOTS=1
+      - name: Save snapshot data cache
+        if: steps.restore-cache-snapshots-debug.outputs.cache-hit != 'true'
+        id: save-cache-snapshots-debug
+        uses: actions/cache/save@v4
+        with:
+          path: ${{github.workspace}}/build/debug/test/snapshots/
+          key: snapshots-${{ env.snapshot_version }}
       - name: Build library
         run: cmake --build ${{github.workspace}}/build/debug --config Debug
       - name: Test
@@ -72,8 +72,6 @@ jobs:
           path: ${{github.workspace}}/build/debug/test/snapshots/
   release-build:
     runs-on: ${{ matrix.os }}
-    env:
-      snapshot_version: v1.5.0
     strategy:
       fail-fast: false
       matrix:
@@ -125,22 +123,13 @@ jobs:
         run: |
           echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
           echo "CMAKE_CONFIGURATION_TYPES=Release" >> "$env:GITHUB_ENV"
-      - name: Cache snapshot data
+      - name: Restore snapshot data cache
         if: matrix.os == 'ubuntu-latest'
-        id: cache-snapshots-release
-        uses: actions/cache@v4
+        id: restore-cache-snapshots-release
+        uses: actions/cache/restore@v4
         with:
           path: test/snapshots
           key: snapshots-${{ env.snapshot_version }}
-      - name: Download and extract snapshot data
-        if: matrix.os == 'ubuntu-latest' && steps.cache-snapshots-release.outputs.cache-hit != 'true'
-        working-directory: test/snapshots
-        shell: bash
-        run: |
-          curl -L -o snapshot_data.tar.gz \
-          "https://github.com/TopoToolbox/snapshot_data/releases/download/$snapshot_version/snapshot_data.tar.gz"
-          tar -xzf snapshot_data.tar.gz
-          shasum -c --status sha256sum.txt
       - name: Configure static library
         run: >
           cmake -B ${{github.workspace}}/build/static
@@ -151,6 +140,14 @@ jobs:
           -DBUILD_SHARED_LIBS=OFF
           --profiling-format=google-trace
           --profiling-output ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
+          -DTT_DOWNLOAD_SNAPSHOTS=1
+      - name: Save snapshot data cache
+        if: matrix.os == 'ubuntu-latest' && steps.restore-cache-snapshots-release.outputs.cache-hit != 'true'
+        id: save-cache-snapshots-release
+        uses: actions/cache/save@v4
+        with:
+          path: ${{github.workspace}}/build/static/test/snapshots/
+          key: snapshots-${{ env.snapshot_version }}
       - name: Build static library
         run: cmake --build ${{github.workspace}}/build/static --config Release
       - name: Test static library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,9 +59,52 @@ set_tests_properties(excesstopography PROPERTIES ENVIRONMENT_MODIFICATION
 # TEST: snapshots
 #
 # Runs the snapshot tests from available snapshot data
-include(FindGDAL)
+OPTION(TT_DOWNLOAD_SNAPSHOTS "Download snapshot test data if it is not already present in test/snapshots/data" OFF)
 
-if (GDAL_FOUND)
+set(TT_SNAPSHOT_VERSION v1.5.0)
+
+# This is the SHA256 hash of the above version's snapshot_data.tar.gz archive
+set(TT_SNAPSHOT_HASH 20ae12f69e63f2c2fbcd27507bbbf7d1c67b57e41db56075c014ebee7fd873e4)
+
+set(TT_SNAPSHOT_DATA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/snapshots/data)
+
+include(FetchContent)
+
+if (EXISTS ${TT_SNAPSHOT_DATA_PATH})
+  message(STATUS "Found existing snapshot data, copying it into the build directory")
+  
+  file(COPY ${TT_SNAPSHOT_DATA_PATH}
+       DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/snapshots/)
+  set(TT_SNAPSHOT_DIR ${CMAKE_CURRENT_BINARY_DIR}/snapshots/data)
+
+  message(STATUS "Snapshot data directory: ${TT_SNAPSHOT_DIR}")
+elseif(TT_DOWNLOAD_SNAPSHOTS)
+  # If the snapshot data does not yet exist at test/snapshot/data, but
+  # we still want to download the snapshots, we do it with
+  # FetchContent
+  message(STATUS "Downloading snapshot data")
+
+  FetchContent_Declare(
+    snapshot_data
+    URL https://github.com/TopoToolbox/snapshot_data/releases/download/${TT_SNAPSHOT_VERSION}/snapshot_data.tar.gz
+    URL_HASH SHA256=${TT_SNAPSHOT_HASH}
+    SOURCE_DIR snapshots/data/
+    DOWNLOAD_EXTRACT_TIMESTAMP false
+  )
+  FetchContent_MakeAvailable(snapshot_data)
+
+  set(TT_SNAPSHOT_DIR ${snapshot_data_SOURCE_DIR})
+  message(STATUS "Snapshot data directory: ${TT_SNAPSHOT_DIR}")
+else()
+  # If we did not download the snapshot data, and the snapshot data
+  # was not provided, we unset TT_SNAPSHOT_DIR so that we do not build
+  # the snapshot test
+  unset(TT_SNAPSHOT_DIR)
+  message(STATUS "Could not find snapshot data. Snapshot tests will not be run")
+endif()
+
+find_package(GDAL CONFIG)
+if (GDAL_FOUND AND TT_SNAPSHOT_DIR)
   add_executable(snapshot snapshot.cpp utils.c)
   if (TT_SANITIZE AND NOT MSVC)
     # Set up the AddressSanitizer flags
@@ -70,11 +113,7 @@ if (GDAL_FOUND)
   endif()
   target_link_libraries(snapshot PRIVATE topotoolbox GDAL::GDAL)
 
-  # Copy test snapshots to output
-  add_custom_target(copy-test-files ALL
-    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/snapshots ${CMAKE_CURRENT_BINARY_DIR}/snapshots)
-
-  add_test(NAME snapshot COMMAND snapshot snapshots/data)
+  add_test(NAME snapshot COMMAND snapshot ${TT_SNAPSHOT_DIR})
   set_tests_properties(snapshot PROPERTIES ENVIRONMENT_MODIFICATION
     "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 endif()


### PR DESCRIPTION
Resolves #175 

This replaces the curl script in the CI configuration with a CMake FetchContent declaration. If snapshot data is present in the test/snapshots/data directory during configuration, then it will be used instead of downloading the new snapshot data.

This change increases the duplication of the snapshot version number, which now must be changed in .github/workflows/ci.yaml to make sure that the correct data is cached, and in test/CMakeLists.txt, to make sure the correct data is fetched. The hash of the snapshot archive is also needed by FetchContent, and this is different from the checksums that we provide in the snapshot_data repository.

This change also requires slightly more complicated caching logic in the CI workflow: the location of the cached data is not the location where CMake downloads the data, so we need separate restore and save steps for the cache.

This will also download the snapshot data (or restore it from the cache) on Windows and macos runners, but the snapshot tests will still not run because we don't install GDAL on those platforms.