### PR TITLE
Revert change to GDAL find_package

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,7 +103,7 @@ else()
   message(STATUS "Could not find snapshot data. Snapshot tests will not be run")
 endif()
 
-find_package(GDAL CONFIG)
+include(FindGDAL)
 if (GDAL_FOUND AND TT_SNAPSHOT_DIR)
   add_executable(snapshot snapshot.cpp utils.c)
   if (TT_SANITIZE AND NOT MSVC)


### PR DESCRIPTION
I made this change in #176 because the FindGDAL module is deprecated, but the new find_package support is only provided by GDAL >= 3.5. This works on GitHub Actions, because we run on Ubuntu 24.04, which I believe provides GDAL 3.8. However, my home system is running Ubuntu 22.04, which is still on GDAL 3.4, so I would like to keep the older system around for a while. We should watch out for this deprecation, however.