### PR TITLE
Implement hillshade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  snapshot_version: v1.5.0
+  snapshot_version: v1.6.0
 
 on:
   pull_request:

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1422,4 +1422,93 @@ TOPOTOOLBOX_API
 void drainagebasins(ptrdiff_t *basins, ptrdiff_t *source, ptrdiff_t *target,
                     ptrdiff_t edge_count, ptrdiff_t dims[2]);
 
+/**
+   @brief Compute the gradient of a DEM using a second-order finite difference
+approximation
+
+   @param[out] p0 The gradient in the first dimension
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`
+
+   `p0` will contain the gradient in the first dimension of the array
+   as specified by `dims`. Whether this corresponds to the positive or
+   negative x or y direction depends on the memory layout and
+   coordinate system of the array.
+   @endparblock
+
+   @param[out] p1 The gradient in the second dimension
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`
+
+   `p1` will contain the gradient in the second dimension of the array
+   as specified by `dims`. Whether this corresponds to the positive or
+   negative x or y direction depends on the memory layout and
+   coordinate system of the array.
+   @endparblock
+
+   @param[in] dem The input digital elevation model
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`
+   @endparblock
+
+   @param[in] cellsize The horizontal resolution of the digital elevation model
+
+   @param[in] dims The dimensions of the arrays
+   @parblock
+   A pointer to a `ptrdiff_t` array of size 2
+
+   The fastest changing dimension should be provided first. For column-major
+   arrays, `dims = {nrows,ncols}`. For row-major arrays, `dims = {ncols,nrows}`.
+   @endparblock
+ */
+TOPOTOOLBOX_API
+void gradient_secondorder(float *p0, float *p1, float *dem, float cellsize,
+                          ptrdiff_t dims[2]);
+
+/**
+   @brief Compute a hillshade of the supplied digital elevation model
+
+   @param[out] output The output hillshade
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[out] nx The component of the surface normal in the x direction
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[out] ny The component of the surface normal in the y direction
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[out] nz The component of the surface normal in the z direction
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[in] dem The input digital elevation model
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[in] azimuth The azimuth angle of the light source (radians clockwise
+from north)
+   @param[in] altitude The altitude angle of the light source (radians above the
+horizon)
+   @param[in] cellsize The spatial resolution of the DEM
+
+   @param[in] dims The dimensions of the arrays
+   @parblock
+   A pointer to a `ptrdiff_t` array of size 2
+
+   The fastest changing dimension should be provided first. For column-major
+   arrays, `dims = {nrows,ncols}`. For row-major arrays, `dims = {ncols,nrows}`.
+   @endparblock
+ */
+TOPOTOOLBOX_API
+void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
+               float azimuth, float altitude, float cellsize,
+               ptrdiff_t dims[2]);
 #endif  // TOPOTOOLBOX_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(topotoolbox
   flow_accumulation.c
   streamquad.c
   drainagebasins.c
+  hillshade.c
 )
 
 # Define the include directory

--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -1,3 +1,5 @@
+#define TOPOTOOLBOX_BUILD
+
 #include <math.h>
 
 #include "topotoolbox.h"
@@ -75,6 +77,7 @@ void normal_vectors(float *restrict nx, float *restrict ny, float *restrict nz,
   }
 }
 
+TOPOTOOLBOX_API
 void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
                float azimuth, float altitude, float cellsize,
                ptrdiff_t dims[2]) {

--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -1,0 +1,95 @@
+#include <math.h>
+
+#include "topotoolbox.h"
+
+#define PI 3.14159265358979323846f
+#define PI_2 1.57079632679489661923f
+
+TOPOTOOLBOX_API
+void gradient_secondorder(float *restrict p0, float *restrict p1, float *dem,
+                          float cellsize, ptrdiff_t dims[2]) {
+  // Compute second order
+  ptrdiff_t m = dims[0];
+  ptrdiff_t n = dims[1];
+
+  // Boundaries use a stencil of [-3 4 -1]/(2*cs) and [1 -4 3]/(2*cs)
+  // Interior points use a stencil of [-1 0 1]/(2*cs)
+
+  // Compute gradient in the first dimension
+  for (ptrdiff_t j = 0; j < n; j++) {
+    ptrdiff_t i = 0;
+
+    p0[j * m + i] =
+        -dem[j * m + i + 2] + 4 * dem[j * m + i + 1] - 3 * dem[j * m + i];
+    p0[j * m + i] /= 2 * cellsize;
+
+    for (i = 1; i < m - 1; i++) {
+      p0[j * m + i] =
+          (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+    }
+
+    i = m - 1;
+    p0[j * m + i] =
+        dem[j * m + i - 2] - 4 * dem[j * m + i - 1] + 3 * dem[j * m + i];
+    p0[j * m + i] /= 2 * cellsize;
+  }
+
+  // Compute gradient in the second dimension
+  ptrdiff_t j = 0;
+  for (ptrdiff_t i = 0; i < m; i++) {
+    p1[j * m + i] = -dem[(j + 2) * m + i] + 4 * dem[(j + 1) * m + i] -
+                    3 * dem[(j + 0) * m + i];
+    p1[j * m + i] /= 2 * cellsize;
+  }
+
+  for (j = 1; j < n - 1; j++) {
+    for (ptrdiff_t i = 0; i < m; i++) {
+      p1[j * m + i] =
+          (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+    }
+  }
+
+  j = n - 1;
+  for (ptrdiff_t i = 0; i < m; i++) {
+    p1[j * m + i] =
+        dem[(j - 2) * m + i] - 4 * dem[(j - 1) * m + i] + 3 * dem[j * m + i];
+    p1[j * m + i] /= 2 * cellsize;
+  }
+}
+
+void normal_vectors(float *restrict nx, float *restrict ny, float *restrict nz,
+                    float *dem, float cellsize, ptrdiff_t dims[2]) {
+  gradient_secondorder(nx, ny, dem, cellsize, dims);
+
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float dx = nx[j * dims[0] + i];
+      float dy = ny[j * dims[0] + i];
+
+      float inorm = 1.0 / sqrtf(dx * dx + dy * dy + 1.0);
+
+      nx[j * dims[0] + i] *= -inorm;
+      ny[j * dims[0] + i] *= -inorm;
+      nz[j * dims[0] + i] = inorm;
+    }
+  }
+}
+
+void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
+               float azimuth, float altitude, float cellsize,
+               ptrdiff_t dims[2]) {
+  normal_vectors(nx, ny, nz, dem, cellsize, dims);
+
+  float sx = sinf(PI_2 - altitude) * cosf(azimuth);
+  float sy = sinf(PI_2 - altitude) * sinf(azimuth);
+  float sz = cosf(PI_2 - altitude);
+
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float x = nx[j * dims[0] + i];
+      float y = ny[j * dims[0] + i];
+      float z = nz[j * dims[0] + i];
+      output[j * dims[0] + i] = x * sx + y * sy + z * sz;
+    }
+  }
+}

--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -66,7 +66,7 @@ void normal_vectors(float *restrict nx, float *restrict ny, float *restrict nz,
       float dx = nx[j * dims[0] + i];
       float dy = ny[j * dims[0] + i];
 
-      float inorm = 1.0 / sqrtf(dx * dx + dy * dy + 1.0);
+      float inorm = 1.0f / sqrtf(dx * dx + dy * dy + 1.0);
 
       nx[j * dims[0] + i] *= -inorm;
       ny[j * dims[0] + i] *= -inorm;

--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -66,7 +66,7 @@ void normal_vectors(float *restrict nx, float *restrict ny, float *restrict nz,
       float dx = nx[j * dims[0] + i];
       float dy = ny[j * dims[0] + i];
 
-      float inorm = 1.0f / sqrtf(dx * dx + dy * dy + 1.0);
+      float inorm = 1.0f / sqrtf(dx * dx + dy * dy + 1.0f);
 
       nx[j * dims[0] + i] *= -inorm;
       ny[j * dims[0] + i] *= -inorm;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,10 +61,10 @@ set_tests_properties(excesstopography PROPERTIES ENVIRONMENT_MODIFICATION
 # Runs the snapshot tests from available snapshot data
 OPTION(TT_DOWNLOAD_SNAPSHOTS "Download snapshot test data if it is not already present in test/snapshots/data" OFF)
 
-set(TT_SNAPSHOT_VERSION v1.5.0)
+set(TT_SNAPSHOT_VERSION v1.6.0)
 
 # This is the SHA256 hash of the above version's snapshot_data.tar.gz archive
-set(TT_SNAPSHOT_HASH 20ae12f69e63f2c2fbcd27507bbbf7d1c67b57e41db56075c014ebee7fd873e4)
+set(TT_SNAPSHOT_HASH 0034ff2843bdbd3ca26ae2a5749baf813e4ff82d0d1fef5b9ba1ef9a4c43784b)
 
 set(TT_SNAPSHOT_DATA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/snapshots/data)
 


### PR DESCRIPTION
Resolves #111 

This patch implements `hillshade` for computing hillshade visualizations of digital elevation models. It successfully reproduces the outputs of `hillshade` from TopoToolbox v2 on the snapshot test data.

Two new functions are added to the API. `gradient_secondorder` computes the gradient of the DEM using a second-order finite difference approximation that is equivalent to that used by MATLAB in `surfnorm` and by `numpy.gradient`. This function is used elsewhere by TopoToolbox functions (such as `aspect`) and might be useful in those places, though its performance against optimized versions has not been thoroughly evaluated.

`hillshade` computes the hillshade of the DEM by computing normal vectors using `gradient_secondorder` and evaluating the dot product of the normal vectors and the specified lighting vector.

A snapshot test of the hillshade raster using v1.6.0 of the snapshot data is added to `test/snapshot.cpp`, and the snapshot data version is bumped in the necessary locations.