### PR TITLE
Correct the hillshade azimuth angle

### DIFF
--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -83,8 +83,8 @@ void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
                ptrdiff_t dims[2]) {
   normal_vectors(nx, ny, nz, dem, cellsize, dims);
 
-  float sx = sinf(PI_2 - altitude) * cosf(azimuth);
-  float sy = sinf(PI_2 - altitude) * sinf(azimuth);
+  float sx = sinf(PI_2 - altitude) * cosf(azimuth - PI_2);
+  float sy = sinf(PI_2 - altitude) * sinf(azimuth - PI_2);
   float sz = cosf(PI_2 - altitude);
 
   for (ptrdiff_t j = 0; j < dims[1]; j++) {

--- a/test/snapshot.cpp
+++ b/test/snapshot.cpp
@@ -223,7 +223,7 @@ struct SnapshotData {
   int test_hillshade() {
     // Azimuth and altitude are 315 and 60 degrees in radians
     tt::hillshade(test_hs.data(), test_nx.data(), test_ny.data(),
-                  test_nz.data(), dem.data(), 3.926990816987241,
+                  test_nz.data(), dem.data(), 5.497787143782138,
                   1.047197551196598, cellsize, dims.data());
 
     for (ptrdiff_t j = 0; j < dims[1]; j++) {


### PR DESCRIPTION
The azimuth, as described in the documentation, should be in radians clockwise from north, which means we need to subtract 90 degrees (pi/2 radians) to rotate into the standard x-y coordinate system.