### PR TITLE
Clearly specify the grid-centered coordinate system in hillshade

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1493,10 +1493,22 @@ void gradient_secondorder(float *p0, float *p1, float *dem, float cellsize,
    A pointer to a float array of size `dims[0] * dims[1]`.
    @endparblock
 
-   @param[in] azimuth The azimuth angle of the light source (radians clockwise
-from north)
-   @param[in] altitude The altitude angle of the light source (radians above the
-horizon)
+   @param[in] azimuth The azimuth angle of the light source
+   @parblock
+   `hillshade` expects the azimuth angle to be provided in radians
+   from the first dimension of the grid towards the second dimension
+   of the grid. This is most likely not identical to the geographic
+   azimuth traditionally measured clockwise from north. Callers should
+   take care to rotate their desired azimuth angle into the grid
+   coordinate system depending on the georeferencing of the grid and
+   the memory layout of the array.
+   @endparblock
+
+   @param[in] altitude The altitude angle of the light source
+   @parblock
+   The altitude angle must be provided in radians above the horizon.
+   @endparblock
+
    @param[in] cellsize The spatial resolution of the DEM
 
    @param[in] dims The dimensions of the arrays

--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -83,8 +83,8 @@ void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
                ptrdiff_t dims[2]) {
   normal_vectors(nx, ny, nz, dem, cellsize, dims);
 
-  float sx = sinf(PI_2 - altitude) * cosf(azimuth - PI_2);
-  float sy = sinf(PI_2 - altitude) * sinf(azimuth - PI_2);
+  float sx = sinf(PI_2 - altitude) * cosf(azimuth);
+  float sy = sinf(PI_2 - altitude) * sinf(azimuth);
   float sz = cosf(PI_2 - altitude);
 
   for (ptrdiff_t j = 0; j < dims[1]; j++) {

--- a/test/snapshot.cpp
+++ b/test/snapshot.cpp
@@ -222,8 +222,15 @@ struct SnapshotData {
 
   int test_hillshade() {
     // Azimuth and altitude are 315 and 60 degrees in radians
+    // tt::hillshade requires azimuth to be in radians from the first
+    // dimension towards the second dimension (a right-handed
+    // coordinate system). The DEM data is loaded with the east
+    // coordinates increasing in the first dimensions, and the north
+    // coordinates decreasing in the second dimension. A bearing of
+    // 315 degrees corresponds to 225 degrees (3.927 radians) in the
+    // grid coordinate system.
     tt::hillshade(test_hs.data(), test_nx.data(), test_ny.data(),
-                  test_nz.data(), dem.data(), 5.497787143782138,
+                  test_nz.data(), dem.data(), 3.9269908169872414,
                   1.047197551196598, cellsize, dims.data());
 
     for (ptrdiff_t j = 0; j < dims[1]; j++) {


### PR DESCRIPTION
This choice of coordinate system is arbitrary, but it makes the most sense to work entirely within a grid-based coordinate system, where the "x" axis increases with the first dimension of the grid and the "y" axis increases with the second dimension of the grid. This uses no external information on the orientation of the image. However, the relationship between grid coordinates and geographic coordinates depends on both the coordinate system of the image and the memory layout of the grid.

GDAL's default coordinate system has the first dimension increasing from the left to the right as one looks at the image, while the second dimension increases from top to bottom. If this image is oriented so that north is up, this means that the azimuth desired by `hillshade` increases from the east (0 degrees) towards the south (90 degrees).

If the array is transposed so that it is now in "column-major" order (the default in MATLAB), then the azimuth angle will increase from the south (0 degrees) towards the east (90 degrees).

The choice of coordinate system should be further documented (#168).