### PR TITLE
Only run the release workflow on the main repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'TopoToolbox/libtopotoolbox'
     name: Tag and create a new release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This checks that the release job is running in the TopoToolbox repository rather than a fork and will only make the weekly release if it is running in the main repository.