### PR TITLE
Modify offsets to make row- and column-major indexing consistent 

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -643,10 +643,17 @@ void excesstopography_fmm3d(float *excess, ptrdiff_t *heap, ptrdiff_t *back,
    The fastest changing dimension should be provided first. For column-major
    arrays, `dims = {nrows,ncols}`. For row-major arrays, `dims = {ncols,nrows}`.
    @endparblock
+
+   @param[in] order The memory order of the underlying array
+   @parblock
+   0 for column-major, 1 for row-major
+
+   @endparblock
  */
 TOPOTOOLBOX_API
 void flow_routing_d8_carve(ptrdiff_t *node, uint8_t *direction, float *dem,
-                           float *dist, int32_t *flats, ptrdiff_t dims[2]);
+                           float *dist, int32_t *flats, ptrdiff_t dims[2],
+                           unsigned int order);
 
 /**
    @brief Compute downstream pixel indices from flow directions
@@ -686,13 +693,19 @@ void flow_routing_d8_carve(ptrdiff_t *node, uint8_t *direction, float *dem,
    arrays, `dims = {nrows,ncols}`. For row-major arrays, `dims = {ncols,nrows}`.
    @endparblock
 
+   @param[in] order The memory order of the underlying array
+   @parblock
+   0 for column-major, 1 for row-major
+
+   @endparblock
+
    @return The number of valid edges contained in the `source` and `target`
    arrays
  */
 TOPOTOOLBOX_API
 ptrdiff_t flow_routing_d8_edgelist(ptrdiff_t *source, ptrdiff_t *target,
                                    ptrdiff_t *node, uint8_t *direction,
-                                   ptrdiff_t dims[2]);
+                                   ptrdiff_t dims[2], unsigned int order);
 
 /**
    @brief Compute flow accumulation

--- a/src/flow_routing.c
+++ b/src/flow_routing.c
@@ -10,7 +10,8 @@
 // Compute the steepest descent flow direction from the DEM with flow
 // routed over flat regions by the auxiliary topography in dist.
 uint8_t compute_flowdirection(ptrdiff_t i, ptrdiff_t j, float *dem, float *dist,
-                              int32_t *flats, ptrdiff_t dims[2]) {
+                              int32_t *flats, ptrdiff_t dims[2],
+                              unsigned int order) {
   int32_t is_flat = flats[j * dims[0] + i] & 1;
   float z = is_flat > 0 ? dist[j * dims[0] + i] : dem[j * dims[0] + i];
   uint8_t direction = 0;
@@ -31,7 +32,6 @@ uint8_t compute_flowdirection(ptrdiff_t i, ptrdiff_t j, float *dem, float *dist,
       // ...
     }
    */
-  unsigned int order = 0;
 
   ptrdiff_t ij_offsets[2][8] = {{0, 1, 1, 1, 0, -1, -1, -1},
                                 {1, 1, 0, -1, -1, -1, 0, 1}};
@@ -130,7 +130,8 @@ uint8_t compute_flowdirection_TT2(ptrdiff_t i, ptrdiff_t j, float *dem,
 
 TOPOTOOLBOX_API
 void flow_routing_d8_carve(ptrdiff_t *node, uint8_t *direction, float *dem,
-                           float *dist, int32_t *flats, ptrdiff_t dims[2]) {
+                           float *dist, int32_t *flats, ptrdiff_t dims[2],
+                           unsigned int order) {
   // node contains an array of dims[0] * dims[1] linear pixel indices
   // into dem. These indices are sorted topologically, so that if
   // there is an edge from node u to node v, u comes before v in the
@@ -169,8 +170,6 @@ void flow_routing_d8_carve(ptrdiff_t *node, uint8_t *direction, float *dem,
     }
   }
 
-  unsigned int order = 0;
-
   ptrdiff_t strides[2] = {0};
   if (order & 1) {
     // row-major
@@ -207,7 +206,7 @@ void flow_routing_d8_carve(ptrdiff_t *node, uint8_t *direction, float *dem,
             ptrdiff_t u_j = u / dims[0];
 
             uint8_t flowdir =
-                compute_flowdirection(u_i, u_j, dem, dist, flats, dims);
+                compute_flowdirection(u_i, u_j, dem, dist, flats, dims, order);
 
             if (flowdir == 0) {
               // This node is a sink/outlet
@@ -256,9 +255,7 @@ void flow_routing_d8_carve(ptrdiff_t *node, uint8_t *direction, float *dem,
 TOPOTOOLBOX_API
 ptrdiff_t flow_routing_d8_edgelist(ptrdiff_t *source, ptrdiff_t *target,
                                    ptrdiff_t *node, uint8_t *direction,
-                                   ptrdiff_t dims[2]) {
-  unsigned int order = 0;  // 0 == column-major, 1 == row-major
-
+                                   ptrdiff_t dims[2], unsigned int order) {
   // For an array of size {m,n}, strides is {n,1} if row-major, {1, m} if
   // column-major Note dims = {m,n} for column-major, {n,m} for row-major
   ptrdiff_t strides[2] = {0};

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -667,11 +667,11 @@ struct FlowRoutingData {
              back.data(), dims.data());
 
     tt::flow_routing_d8_carve(nodes.data(), direction.data(), filled_dem.data(),
-                              dist.data(), flats.data(), dims.data());
+                              dist.data(), flats.data(), dims.data(), 0);
 
     edge_count =
         tt::flow_routing_d8_edgelist(source.data(), target.data(), nodes.data(),
-                                     direction.data(), dims.data());
+                                     direction.data(), dims.data(), 0);
 
     tt::flow_accumulation_edgelist(accum2.data(), source.data(), target.data(),
                                    fraction.data(), NULL, edge_count,
@@ -695,11 +695,11 @@ struct FlowRoutingData {
              back.data(), dims.data());
 
     tt::flow_routing_d8_carve(nodes.data(), direction.data(), filled_dem.data(),
-                              dist.data(), flats.data(), dims.data());
+                              dist.data(), flats.data(), dims.data(), 0);
 
     edge_count =
         tt::flow_routing_d8_edgelist(source.data(), target.data(), nodes.data(),
-                                     direction.data(), dims.data());
+                                     direction.data(), dims.data(), 0);
 
     tt::flow_accumulation_edgelist(accum2.data(), source.data(), target.data(),
                                    fraction.data(), NULL, edge_count,


### PR DESCRIPTION
Flow routing should produce the same results for identical DEMs stored in either row- or column-major order. However, we search sequentially through neighboring pixels to find the steepest gradient, and we choose the first neighbor we encounter if two neighbors have the same gradient. For column-major arrays, we start with the east neighbor and check in a clockwise direction. But for row-major arrays, using the same offsets in the i and j directions starts with the south neighbor and checks counterclockwise.

This change introduces a new parameter (`order`) that is zero for column-major arrays and one for row-major arrays. Think about it as the index of the dimension whose index changes the fastest as you iterate linearly through the array. This parameter is used to construct the offset arrays so that neighbors are visited in the same order regardless of the memory layout of the array.

This is a breaking API change to libtopotoolbox, and downstream consumers will need to be changed. To preserve the current behavior, pass 0 to the `order` parameter of `flow_routing_d8_carve` and `flow_routing_d8_edgelist`. As noted above, this behavior is incorrect. You should pass 0 for column-major arrays and 1 for row-major arrays.