### PR TITLE
Fix a small boundary condition issue in Graphflood

### DIFF
--- a/src/graphflood/graphflood.c
+++ b/src/graphflood/graphflood.c
@@ -58,6 +58,7 @@ void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
       // Note that a lot of the checks are actually already done by the graph
       // calculation
       if (rec == node) continue;
+      if (can_out(node, BCs)) continue;
       // Additional check: if no water and no input, no need to calculate
       if (Zw[node] == Z[node] && Qwin[node] == 0) continue;
 
@@ -144,6 +145,7 @@ void _graphflood_full_mfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
 
       // If no data: pass
       if (is_nodata(node, BCs)) continue;
+      if (can_out(node, BCs)) continue;
 
       // First, incrementing local Qwin
       Qwin[node] += Precipitations[node] * dx * dx;

--- a/src/graphflood/graphflood.c
+++ b/src/graphflood/graphflood.c
@@ -58,6 +58,7 @@ void _graphflood_full_sfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
       // Note that a lot of the checks are actually already done by the graph
       // calculation
       if (rec == node) continue;
+      // Boundary condition: if the flow can out I do not touch hw
       if (can_out(node, BCs)) continue;
       // Additional check: if no water and no input, no need to calculate
       if (Zw[node] == Z[node] && Qwin[node] == 0) continue;
@@ -145,6 +146,7 @@ void _graphflood_full_mfd(GF_FLOAT* Z, GF_FLOAT* hw, uint8_t* BCs,
 
       // If no data: pass
       if (is_nodata(node, BCs)) continue;
+      // Boundary condition: if the flow can out I do not touch hw
       if (can_out(node, BCs)) continue;
 
       // First, incrementing local Qwin


### PR DESCRIPTION
In Graphflood and for small domains, there is a risk of "piling up" water near the boundaries because, until now, the flow does not out properly.

This small PR fixes this behaviour by not changing flow depth at boundaries `can_out`.

In the future, I will add some options (e.g. constant slope, constant hw, ...).