### PR TITLE
Add bitwise or accumulation to traverse_up_u32_or_and

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -927,15 +927,19 @@ void streamquad_trapz_f64(double *integral, double *integrand,
                           ptrdiff_t edge_count);
 
 /**
-   @brief Upstream traversal with bitwise and
+   @brief Upstream traversal in the (or, and) semiring
 
-   Integrates the input node attribute list upstream using bitwise
-   and:
+   Traverses the stream network in the upstream direction,
+   accumulating the values in `output` with edge weights given by the
+   `weights` array. The weights are applied with a bitwise and and
+   accumulated with a bitwise or.
 
-   for (u=>v) in edges:
-     output[u] = output[v] & input[u];
+   ```
+   for (e = (u,v) in edges:
+     output[u] = output[u] | (output[v] & input[e]);
+   ```
 
-   @param[out] output The integrated output
+   @param[out] output The accumulated output
    @parblock
    A pointer to a `uint32_t` array representing a node attribute list
 
@@ -944,13 +948,12 @@ void streamquad_trapz_f64(double *integral, double *integrand,
    `source` or `target` arrays.
    @endparblock
 
-   @param[in] input The quantity to be integrated
+   @param[in] weights The edge weights
    @parblock
-   A pointer to a `uint32_t` array representing a node attribute list
+   A pointer to a `uint32_t` array representing an edge attribute list
 
    If the stream network has N nodes, this array should have a length
-   N. This value must not be less than the largest value in either the
-   `source` or `target` arrays.
+   edge_count.
    @endparblock
 
    @param[in] source The source node of each edge in the stream
@@ -975,8 +978,9 @@ void streamquad_trapz_f64(double *integral, double *integrand,
    @param[in] edge_count The number of edges in the stream network
  */
 TOPOTOOLBOX_API
-void traverse_up_u32_and(uint32_t *output, uint32_t *input, ptrdiff_t *source,
-                         ptrdiff_t *target, ptrdiff_t edge_count);
+void traverse_up_u32_or_and(uint32_t *output, uint32_t *weights,
+                            ptrdiff_t *source, ptrdiff_t *target,
+                            ptrdiff_t edge_count);
 
 /**
    @brief Downstream traversal in the Boolean ({0,1}, or, and) semiring

--- a/src/streamquad.c
+++ b/src/streamquad.c
@@ -35,13 +35,14 @@ void streamquad_trapz_f64(double *integral, double *integrand,
 }
 
 TOPOTOOLBOX_API
-void traverse_up_u32_and(uint32_t *output, uint32_t *input, ptrdiff_t *source,
-                         ptrdiff_t *target, ptrdiff_t edge_count) {
+void traverse_up_u32_or_and(uint32_t *output, uint32_t *input,
+                            ptrdiff_t *source, ptrdiff_t *target,
+                            ptrdiff_t edge_count) {
   for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
     ptrdiff_t u = source[e];
     ptrdiff_t v = target[e];
 
-    output[u] = output[v] & input[u];
+    output[u] = output[u] | (output[v] & input[e]);
   }
 }
 

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -576,9 +576,7 @@ int32_t test_db_traverse(ptrdiff_t *basins, ptrdiff_t *source,
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
       ptrdiff_t p = j * dims[0] + i;
       if (indegree[p] > 0 && outdegree[p] == 0) {
-        assert(0 <= basins[p]);
-        assert(basins[p] < UINT32_MAX);
-        traverse_basins[p] = basins[p];
+        traverse_basins[p] = (uint32_t)basins[p];
       }
     }
   }

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -561,18 +561,23 @@ int32_t test_propagatevalues(float *pvF32, double *pvF64, uint8_t *pvU8,
 // drainagebasins should return the same drainage basins computed
 // using an appropriately initialized traverse_up_u32_or_and.
 int32_t test_db_traverse(ptrdiff_t *basins, ptrdiff_t *source,
-                         ptrdiff_t *target, ptrdiff_t dims[2]) {
-  std::vector<uint32_t> ones(dims[0] * dims[1], 0xffffffff);
-  std::vector<uint32_t> traverse_basins(dims[0] * dims[1], 0);
+                         ptrdiff_t *target, ptrdiff_t edge_count,
+                         ptrdiff_t dims[2]) {
+  std::vector<uint32_t> ones(edge_count, 0xffffffff);           // Edge weights
+  std::vector<uint32_t> traverse_basins(dims[0] * dims[1], 0);  // Basin labels
+  std::vector<uint8_t> indegree(dims[0] * dims[1], 0);
+  std::vector<uint8_t> outdegree(dims[0] * dims[1], 0);
 
-  ptrdiff_t edge_count = dims[0] * dims[1];
-  for (ptrdiff_t e = 0; e < edge_count; e++) {
-    ptrdiff_t src = source[e];
-    ptrdiff_t tgt = target[e];
-    if (tgt < 0) {
-      // src is an outlet
-      // initialize it with the same value as basins
-      traverse_basins[src] = basins[src];
+  // Identify outlets
+  tt::edgelist_degree(indegree.data(), outdegree.data(), source, target,
+                      dims[0] * dims[1], edge_count);
+
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t p = j * dims[0] + i;
+      if (indegree[p] > 0 && outdegree[p] == 0) {
+        traverse_basins[p] = basins[p];
+      }
     }
   }
   tt::traverse_up_u32_or_and(traverse_basins.data(), ones.data(), source,
@@ -833,7 +838,8 @@ struct FlowRoutingData {
     drainagebasins();
     test_drainagebasins(basins.data(), source.data(), target.data(), edge_count,
                         dims.data());
-    test_db_traverse(basins.data(), source.data(), target.data(), dims.data());
+    test_db_traverse(basins.data(), source.data(), target.data(), edge_count,
+                     dims.data());
 
     // route_flow and route_flow_hybrid only run the edgelist variant
     // of flow_accumulation, so we must run it explicitly.

--- a/test/random_dem.cpp
+++ b/test/random_dem.cpp
@@ -576,6 +576,8 @@ int32_t test_db_traverse(ptrdiff_t *basins, ptrdiff_t *source,
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
       ptrdiff_t p = j * dims[0] + i;
       if (indegree[p] > 0 && outdegree[p] == 0) {
+        assert(0 <= basins[p]);
+        assert(basins[p] < UINT32_MAX);
         traverse_basins[p] = basins[p];
       }
     }


### PR DESCRIPTION
As described in https://github.com/TopoToolbox/libtopotoolbox/issues/164, 
this makes the semiring pattern in the traversal more obvious and parallels
the naming of `traverse_down_u32_or_and`.

A test is added to test/random_dem.cpp that computes drainage basins
using traverse_up_u32_or_and and ensures that it is identical to our
existing drainagebasins computation. This also tries a new testing
pattern where test-specific data is initialized within the test
function rather than as part of the very large FlowRoutingData class.