### PR TITLE
Rename morphology/reconstruct.c to reconstruct.c in the Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,9 @@ jobs:
         with:
           name: snapshot_test_output
           path: ${{github.workspace}}/build/debug/test/snapshots/
+      - name: Build library with Makefile
+        working-directory: ${{github.workspace}}/src
+        run: make
   release-build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 .SUFFIXES:
 
-SRCS=excesstopography.c fillsinks.c flow_accumulation.c flow_routing.c gradient8.c gwdt.c identifyflats.c morphology/reconstruct.c priority_queue.c streamquad.c topotoolbox.c graphflood/gf_utils.c graphflood/sfgraph.c graphflood/priority_flood_standalone.c graphflood/gf_flowacc.c graphflood/graphflood.c
+SRCS=excesstopography.c fillsinks.c flow_accumulation.c flow_routing.c gradient8.c gwdt.c identifyflats.c reconstruct.c priority_queue.c streamquad.c topotoolbox.c graphflood/gf_utils.c graphflood/sfgraph.c graphflood/priority_flood_standalone.c graphflood/gf_flowacc.c graphflood/graphflood.c
 
 OBJS=$(SRCS:.c=.o)
 


### PR DESCRIPTION
This change introduced in #178 was not propagated to the Makefile, which is used in the topotoolboxr build.