### PR TITLE
Add a lower-memory version of hillshade

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1583,17 +1583,12 @@ void gradient_secondorder(float *p0, float *p1, float *dem, float cellsize,
    A pointer to a float array of size `dims[0] * dims[1]`.
    @endparblock
 
-   @param[out] nx The component of the surface normal in the x direction
+   @param[out] dx The surface gradient in the first dimension
    @parblock
    A pointer to a float array of size `dims[0] * dims[1]`.
    @endparblock
 
-   @param[out] ny The component of the surface normal in the y direction
-   @parblock
-   A pointer to a float array of size `dims[0] * dims[1]`.
-   @endparblock
-
-   @param[out] nz The component of the surface normal in the z direction
+   @param[out] dy The surface gradient in the second dimension
    @parblock
    A pointer to a float array of size `dims[0] * dims[1]`.
    @endparblock
@@ -1630,7 +1625,55 @@ void gradient_secondorder(float *p0, float *p1, float *dem, float cellsize,
    @endparblock
  */
 TOPOTOOLBOX_API
-void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
-               float azimuth, float altitude, float cellsize,
-               ptrdiff_t dims[2]);
+void hillshade(float *output, float *dx, float *dy, float *dem, float azimuth,
+               float altitude, float cellsize, ptrdiff_t dims[2]);
+
+/**
+   @brief Compute a hillshade of the supplied digital elevation model
+
+   The output of `hillshade_fused` should be identical to that of
+   `hillshade`, but the gradient, surface normal and shading loops
+   have been fused to remove the need for intermediate arrays. This
+   causes a slight performance degradation, but significantly reduces
+   the amount of memory needed.
+
+   @param[out] output The output hillshade
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[in] dem The input digital elevation model
+   @parblock
+   A pointer to a float array of size `dims[0] * dims[1]`.
+   @endparblock
+
+   @param[in] azimuth The azimuth angle of the light source
+   @parblock
+   `hillshade` expects the azimuth angle to be provided in radians
+   from the first dimension of the grid towards the second dimension
+   of the grid. This is most likely not identical to the geographic
+   azimuth traditionally measured clockwise from north. Callers should
+   take care to rotate their desired azimuth angle into the grid
+   coordinate system depending on the georeferencing of the grid and
+   the memory layout of the array.
+   @endparblock
+
+   @param[in] altitude The altitude angle of the light source
+   @parblock
+   The altitude angle must be provided in radians above the horizon.
+   @endparblock
+
+   @param[in] cellsize The spatial resolution of the DEM
+
+   @param[in] dims The dimensions of the arrays
+   @parblock
+   A pointer to a `ptrdiff_t` array of size 2
+
+   The fastest changing dimension should be provided first. For column-major
+   arrays, `dims = {nrows,ncols}`. For row-major arrays, `dims = {ncols,nrows}`.
+   @endparblock
+ */
+TOPOTOOLBOX_API
+void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
+                     float cellsize, ptrdiff_t dims[2]);
 #endif  // TOPOTOOLBOX_H

--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -7,6 +7,18 @@
 #define PI 3.14159265358979323846f
 #define PI_2 1.57079632679489661923f
 
+// Compute hillshade value from gradient and illumination vector
+static inline float compute_hillshade(float dx, float dy, float sx, float sy,
+                                      float sz) {
+  float inorm = 1.0f / sqrtf(dx * dx + dy * dy + 1.0f);
+
+  float nx = -dx * inorm;
+  float ny = -dy * inorm;
+  float nz = inorm;
+
+  return nx * sx + ny * sy + nz * sz;
+}
+
 TOPOTOOLBOX_API
 void gradient_secondorder(float *restrict p0, float *restrict p1, float *dem,
                           float cellsize, ptrdiff_t dims[2]) {
@@ -59,40 +71,123 @@ void gradient_secondorder(float *restrict p0, float *restrict p1, float *dem,
   }
 }
 
-void normal_vectors(float *restrict nx, float *restrict ny, float *restrict nz,
-                    float *dem, float cellsize, ptrdiff_t dims[2]) {
-  gradient_secondorder(nx, ny, dem, cellsize, dims);
-
-  for (ptrdiff_t j = 0; j < dims[1]; j++) {
-    for (ptrdiff_t i = 0; i < dims[0]; i++) {
-      float dx = nx[j * dims[0] + i];
-      float dy = ny[j * dims[0] + i];
-
-      float inorm = 1.0f / sqrtf(dx * dx + dy * dy + 1.0f);
-
-      nx[j * dims[0] + i] *= -inorm;
-      ny[j * dims[0] + i] *= -inorm;
-      nz[j * dims[0] + i] = inorm;
-    }
-  }
-}
-
 TOPOTOOLBOX_API
-void hillshade(float *output, float *nx, float *ny, float *nz, float *dem,
-               float azimuth, float altitude, float cellsize,
-               ptrdiff_t dims[2]) {
-  normal_vectors(nx, ny, nz, dem, cellsize, dims);
-
+void hillshade(float *output, float *dx, float *dy, float *dem, float azimuth,
+               float altitude, float cellsize, ptrdiff_t dims[2]) {
   float sx = sinf(PI_2 - altitude) * cosf(azimuth);
   float sy = sinf(PI_2 - altitude) * sinf(azimuth);
   float sz = cosf(PI_2 - altitude);
 
+  gradient_secondorder(dx, dy, dem, cellsize, dims);
+
   for (ptrdiff_t j = 0; j < dims[1]; j++) {
     for (ptrdiff_t i = 0; i < dims[0]; i++) {
-      float x = nx[j * dims[0] + i];
-      float y = ny[j * dims[0] + i];
-      float z = nz[j * dims[0] + i];
-      output[j * dims[0] + i] = x * sx + y * sy + z * sz;
+      float dxij = dx[j * dims[0] + i];
+      float dyij = dy[j * dims[0] + i];
+
+      output[j * dims[0] + i] = compute_hillshade(dxij, dyij, sx, sy, sz);
     }
+  }
+}
+
+////////////////////
+// A lower memory version of hillshade fuses the loops together so
+// intermediate arrays can be avoided
+
+TOPOTOOLBOX_API
+void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
+                     float cellsize, ptrdiff_t dims[2]) {
+  float sx = sinf(PI_2 - altitude) * cosf(azimuth);
+  float sy = sinf(PI_2 - altitude) * sinf(azimuth);
+  float sz = cosf(PI_2 - altitude);
+
+  ptrdiff_t m = dims[0];
+  ptrdiff_t n = dims[1];
+
+  ptrdiff_t i, j;
+
+  j = 0;
+  {
+    i = 0;
+    float dx =
+        (-dem[j * m + i + 2] + 4 * dem[j * m + i + 1] - 3 * dem[j * m + i]) /
+        (2 * cellsize);
+    float dy = (-dem[(j + 2) * m + i] + 4 * dem[(j + 1) * m + i] -
+                3 * dem[(j + 0) * m + i]) /
+               (2 * cellsize);
+    output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+  }
+  for (i = 1; i < (m - 1); i++) {
+    float dx = (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+    float dy = (-dem[(j + 2) * m + i] + 4 * dem[(j + 1) * m + i] -
+                3 * dem[(j + 0) * m + i]) /
+               (2 * cellsize);
+
+    output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+  }
+  {
+    i = m - 1;
+    float dx =
+        (dem[j * m + i - 2] - 4 * dem[j * m + i - 1] + 3 * dem[j * m + i]) /
+        (2 * cellsize);
+    float dy = (-dem[(j + 2) * m + i] + 4 * dem[(j + 1) * m + i] -
+                3 * dem[(j + 0) * m + i]) /
+               (2 * cellsize);
+    output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+  }
+
+  for (j = 1; j < (n - 1); j++) {
+    {
+      i = 0;
+      float dx =
+          (-dem[j * m + i + 2] + 4 * dem[j * m + i + 1] - 3 * dem[j * m + i]) /
+          (2 * cellsize);
+      float dy = (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+      output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+    }
+    for (i = 1; i < (m - 1); i++) {
+      float dx = (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+      float dy = (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+
+      output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+    }
+    {
+      i = m - 1;
+      float dx =
+          (dem[j * m + i - 2] - 4 * dem[j * m + i - 1] + 3 * dem[j * m + i]) /
+          (2 * cellsize);
+      float dy = (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+      output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+    }
+  }
+
+  j = n - 1;
+  {
+    i = 0;
+    float dx =
+        (-dem[j * m + i + 2] + 4 * dem[j * m + i + 1] - 3 * dem[j * m + i]) /
+        (2 * cellsize);
+    float dy =
+        (dem[(j - 2) * m + i] - 4 * dem[(j - 1) * m + i] + 3 * dem[j * m + i]) /
+        (2 * cellsize);
+    output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+  }
+  for (i = 1; i < (m - 1); i++) {
+    float dx = (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+    float dy =
+        (dem[(j - 2) * m + i] - 4 * dem[(j - 1) * m + i] + 3 * dem[j * m + i]) /
+        (2 * cellsize);
+
+    output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
+  }
+  {
+    i = m - 1;
+    float dx =
+        (dem[j * m + i - 2] - 4 * dem[j * m + i - 1] + 3 * dem[j * m + i]) /
+        (2 * cellsize);
+    float dy =
+        (dem[(j - 2) * m + i] - 4 * dem[(j - 1) * m + i] + 3 * dem[j * m + i]) /
+        (2 * cellsize);
+    output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
   }
 }


### PR DESCRIPTION
Addresses #191

`hillshade_fused` should behave identically to `hillshade`, but it requires no intermediate arrays. It is slightly slower than `hillshade` because of different memory access patterns when computing the gradients and differences in handling boundary conditions. It seems like the performance gap closes for larger DEMs, which have more of their pixels on the interior. One might choose to use `hillshade_fused` for larger DEMs.

`hillshade` is also modified so that it takes only two intermediate arrays. These are used to store the surface gradients. The normal vector computation is now inlined. You now only need to allocate 3 DEM-sized arrays (the output and the two gradients) for `hillshade`.

A snapshot test is added to ensure that `hillshade_fused` also replicates the behavior of TT2's `hillshade`.

This is a breaking change. The change to the `hillshade` API will need to be patched in downstream libraries, namely pytopotoolbox.