### PR TITLE
Implement `lowerenv`

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -1676,4 +1676,73 @@ void hillshade(float *output, float *dx, float *dy, float *dem, float azimuth,
 TOPOTOOLBOX_API
 void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
                      float cellsize, ptrdiff_t dims[2]);
+
+/**
+   @brief Compute the lower convex envelope of a stream profile
+
+   @param[inout] elevation A node attribute list of elevations
+   @parblock
+   A pointer to a float array representing a node attribute list.
+
+   `elevation` should be initialized with the elevation of the stream
+   profile whose lower convex envelope will be computed. It will be
+   modified in place.
+   @endparblock
+
+   @param[in] knickpoints A logical node attribute list specifying knickpoints
+   @parblock
+
+   A pointer to a uint8_t array representing a node attribute list.
+
+   The resulting elevation profile will be nonconvex only at nodes
+   whose value in this array is nonzero.
+   @endparblock
+
+   @param[in] distance A node attribute list containing upstream distances
+   @parblock
+
+   A pointer to a float array representing a node attribute list. Each
+   entry should contain the distance upstream from an outlet of the
+   corresponding node.
+   @endparblock
+
+   @param[inout] ix A node attribute list used as an intermediate array
+   @parblock
+
+   A pointer to a ptrdiff_t array representing a node attribute
+   list. It is used as an intermediate array and is initialized as
+   needed within `lowerenv`.
+
+   @endparblock
+
+   @param[inout] onenvelope A node attribute list used as an intermediate array
+   @parblock
+
+   A pointer to a uint8_t array representing a node attribute list. It
+   is used an an intermediate array and is initialized as needed
+   within `lowerenv`.
+
+   @endparblock
+
+   @param[in] source The source node of each edge in the stream network
+   @parblock
+
+   A pointer to a ptrdiff_t array representing an edge attribute list.
+
+   @endparblock
+
+   @param[in] target The target node of each edge in the stream network
+   @parblock
+
+   A pointer to a ptrdiff_t array representing an edge attribute list.
+
+   @endparblock
+
+   @param[in] edge_count The number of edges in the stream network
+   @param[in] node_count The number of nodes in the stream network
+ */
+TOPOTOOLBOX_API
+void lowerenv(float *elevation, uint8_t *knickpoints, float *distance,
+              ptrdiff_t *ix, uint8_t *onenvelope, ptrdiff_t *source,
+              ptrdiff_t *target, ptrdiff_t edge_count, ptrdiff_t node_count);
 #endif  // TOPOTOOLBOX_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(topotoolbox
   streamquad.c
   drainagebasins.c
   hillshade.c
+  knickpoints.c
 )
 
 # Define the include directory

--- a/src/knickpoints.c
+++ b/src/knickpoints.c
@@ -1,0 +1,105 @@
+#define TOPOTOOLBOX_BUILD
+
+#include <math.h>
+
+#include "topotoolbox.h"
+
+ptrdiff_t nnz(ptrdiff_t *ix, ptrdiff_t node_count) {
+  ptrdiff_t n = 0;
+  for (ptrdiff_t i = 0; i < node_count; i++) {
+    n += ix[i] ? 1 : 0;
+  }
+  return n;
+}
+
+TOPOTOOLBOX_API
+void lowerenv(float *elevation, uint8_t *knickpoints, float *distance,
+              ptrdiff_t *ix, uint8_t *onenvelope, ptrdiff_t *source,
+              ptrdiff_t *target, ptrdiff_t edge_count, ptrdiff_t node_count) {
+  // All nodes start out on the envelope
+  for (ptrdiff_t i = 0; i < node_count; i++) {
+    onenvelope[i] = 1;
+  }
+
+  for (ptrdiff_t e = edge_count - 1; e >= 0; e--) {
+    ptrdiff_t u = source[e];
+    ptrdiff_t v = target[e];
+
+    if (onenvelope[u]) {
+      // allpred
+      for (ptrdiff_t i = 0; i < node_count; i++) {
+        ix[i] = 0;
+      }
+      ix[u] = 1;
+      for (ptrdiff_t e1 = edge_count - 1; e1 >= 0; e1--) {
+        ptrdiff_t u1 = source[e1];
+        ptrdiff_t v1 = target[e1];
+
+        ix[u1] = ix[u1] | (ix[v1] & ~knickpoints[v1]);
+      }
+      // end allpred
+
+      if (nnz(ix, node_count) == 0) {
+        // Skip gradient computations if there are no upstream nodes
+        // of u below a knickpoint.
+        continue;
+      }
+
+      // Compute the minimum gradient between v and a point upstream
+      // of v but below any knickpoints.
+      float g = INFINITY;
+      ptrdiff_t idx = -1;
+      for (ptrdiff_t e1 = 0; e1 < edge_count; e1++) {
+        ptrdiff_t u1 = source[e1];
+
+        if (ix[u1]) {
+          float gu =
+              (elevation[u1] - elevation[v]) / (distance[u1] - distance[v]);
+          if (gu < g) {
+            g = gu;
+            idx = u1;
+          }
+        }
+      }
+
+      // Set up fast indexing/tracking visited nodes
+      //
+      // MATLAB uses a separate ixcix array, but we will repurpose the
+      // ix array from above, which is no longer required.
+      //
+      // Initialize ix to -1. If ix[u] = -1, u has been visited or u
+      // has no downstream neighbors.
+      for (ptrdiff_t i = 0; i < node_count; i++) {
+        ix[i] = -1;
+      }
+
+      // ix[u] is the index in the edge lists of the unique edge that
+      // starts at u.
+      for (ptrdiff_t e = 0; e < edge_count; e++) {
+        ix[source[e]] = e;
+      }
+
+      // Visit node v
+      ix[v] = -1;
+
+      // Loop until we hit a node that has been visited.
+      while (ix[idx] >= 0) {
+        ptrdiff_t idx2 = target[ix[idx]];
+
+        // Adjust the distance downward by the minimum gradient we found earlier
+        elevation[idx2] = elevation[idx] - g * (distance[idx] - distance[idx2]);
+
+        // Take idx2 off the envelope, because its elevation has been
+        // updated. It will not be searched in later iterations of the
+        // outer loop, though it may still be updated.
+        onenvelope[idx2] = 0;
+
+        // Mark idx as visited
+        ix[idx] = -1;
+
+        // Visit the downstream neighbor
+        idx = idx2;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This function computes the lower convex envelope of a stream profile and is used in the knickpointfinder to model a convex stream profile, deviations from which indicate the presence of knickpoints.

This more or less copies the MATLAB implementation with a few changes:

The minimum gradient for each reach is computed by explicitly accumulating the minimum over the network rather than by sorting. This avoids dynamic memory allocation for the sorting, but does require that we loop over the whole stream network even when we are examining a portion of it.

`allpred` is inlined into the function, since it is only used once. This is noted with a few comments.

`allpred` is modified so that it represents an upstream traversal in the Boolean semiring. This is different from the MATLAB implementation, which does not have a semiring update step. The MATLAB implementation can miss some reaches above knickpoints and produces stream networks that are not convex.

A random_dem test is added to check that the resulting profile is convex except at knickpoints. Knickpoints are "randomly" generated along the stream profile. The test checks that the gradient of each edge flowing into a node is greater than the gradient leaving that node, except at knickpoints, where this will not be true.