### PR TITLE
Return NaN gradients whenever the DEM is NaN

### DIFF
--- a/src/hillshade.c
+++ b/src/hillshade.c
@@ -39,7 +39,9 @@ void gradient_secondorder(float *restrict p0, float *restrict p1, float *dem,
 
     for (i = 1; i < m - 1; i++) {
       p0[j * m + i] =
-          (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+          isnan(dem[j * m + i])
+              ? NAN
+              : (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
     }
 
     i = m - 1;
@@ -59,7 +61,9 @@ void gradient_secondorder(float *restrict p0, float *restrict p1, float *dem,
   for (j = 1; j < n - 1; j++) {
     for (ptrdiff_t i = 0; i < m; i++) {
       p1[j * m + i] =
-          (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+          isnan(dem[j * m + i])
+              ? NAN
+              : (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
     }
   }
 
@@ -118,7 +122,9 @@ void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
     output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
   }
   for (i = 1; i < (m - 1); i++) {
-    float dx = (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+    float dx = isnan(dem[j * m + i])
+                   ? NAN
+                   : (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
     float dy = (-dem[(j + 2) * m + i] + 4 * dem[(j + 1) * m + i] -
                 3 * dem[(j + 0) * m + i]) /
                (2 * cellsize);
@@ -142,12 +148,21 @@ void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
       float dx =
           (-dem[j * m + i + 2] + 4 * dem[j * m + i + 1] - 3 * dem[j * m + i]) /
           (2 * cellsize);
-      float dy = (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+      float dy =
+          isnan(dem[j * m + i])
+              ? NAN
+              : (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
       output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
     }
     for (i = 1; i < (m - 1); i++) {
-      float dx = (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
-      float dy = (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+      float dx =
+          isnan(dem[j * m + i])
+              ? NAN
+              : (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+      float dy =
+          isnan(dem[j * m + i])
+              ? NAN
+              : (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
 
       output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
     }
@@ -156,7 +171,7 @@ void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
       float dx =
           (dem[j * m + i - 2] - 4 * dem[j * m + i - 1] + 3 * dem[j * m + i]) /
           (2 * cellsize);
-      float dy = (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
+      float dy = isnan(dem[j * m + i]) ? NAN : (dem[(j + 1) * m + i] - dem[(j - 1) * m + i]) / (2 * cellsize);
       output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
     }
   }
@@ -173,7 +188,7 @@ void hillshade_fused(float *output, float *dem, float azimuth, float altitude,
     output[j * m + i] = compute_hillshade(dx, dy, sx, sy, sz);
   }
   for (i = 1; i < (m - 1); i++) {
-    float dx = (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
+    float dx = isnan(dem[j * m + i]) ? NAN : (dem[j * m + i + 1] - dem[j * m + i - 1]) / (2 * cellsize);
     float dy =
         (dem[(j - 2) * m + i] - 4 * dem[(j - 1) * m + i] + 3 * dem[j * m + i]) /
         (2 * cellsize);

--- a/test/snapshot.cpp
+++ b/test/snapshot.cpp
@@ -236,7 +236,8 @@ struct SnapshotData {
       for (ptrdiff_t i = 0; i < dims[0]; i++) {
         float H = test_hs[j * dims[0] + i];
 
-        if (fabsf(H - hs[j * dims[0] + i]) > 1e-4) {
+        if (fabsf(H - hs[j * dims[0] + i]) > 1e-4 ||
+            (isnan(hs[j * dims[0] + i]) && !isnan(H))) {
           write_data_to_file<float, GDT_Float32>(path / "test_hillshade.tif",
                                                  path / "hillshade.tif",
                                                  test_hs, dims);


### PR DESCRIPTION
Because the second-order gradient uses centered differences, a NaN surrounded by valid data can still have a valid gradient, which is inconsistent with the behavior of hillshade in MATLAB. This change checks whether the central pixel is NaN before computing the gradient for the centered difference approximation. The boundaries that use second-order forward and backward differences already access the current pixel, so this is not a problem there.

The comparison in the snapshot test is modified to account for this possibility. The tests fail before the change is applied and pass afterwards.