### PR TITLE
Define the NDEBUG macro in the Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,3 +173,12 @@ jobs:
         with:
           name: ${{matrix.os}}_${{matrix.c_compiler}}_cmake_profiles
           path: ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
+      - name: Build library with Makefile
+        if: ${{ matrix.os != 'windows-latest' }}
+        working-directory: ${{github.workspace}}/src
+        run: make
+      - name: Check that library has no compiled asserts
+        if: ${{ matrix.os != 'windows-latest' }}
+        working-directory: ${{github.workspace}}/src
+        run: |
+          if nm libtopotoolbox.a | grep "assert"; then false; else true; fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,4 +11,4 @@ libtopotoolbox.a: $(OBJS)
 
 .SUFFIXES: .c .o
 .c.o:
-	$(CC) $(CFLAGS) -DTOPOTOOLBOX_STATICLIB -I../include -c -o $@ $<
+	$(CC) $(CFLAGS) -DTOPOTOOLBOX_STATICLIB -DNDEBUG -I../include -c -o $@ $<


### PR DESCRIPTION
Resolves #200

This macro turns off the asserts that we use for testing in various functions. CMake does this for us on many platforms, but R uses our Makefile to compile libtopotoolbox, and for some reason NDEBUG does not get properly defined on macos, causing the asserts to be left in the compiled code, and R does not accept C code that has asserts, because it could potentially abort the R session.

I have also added a test to the CI configuration that build the Makefiles in CI on ubuntu and macos and check that no asserts are left in the symbol table.