### PR TITLE
Update and pin reusable workflows, drop msvc-dev-cmd workflow and switch to windows-2025-vs2026

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025-vs2026]
         c_compiler: [gcc, clang, cl]
         include:
           - c_compiler: gcc
@@ -72,9 +72,9 @@ jobs:
           - c_compiler: cl
             cpp_compiler: cl
         exclude:
-          - os: windows-latest
+          - os: windows-2025-vs2026
             c_compiler: gcc
-          - os: windows-latest
+          - os: windows-2025-vs2026
             c_compiler: clang
           - os: macos-latest
             c_compiler: cl
@@ -99,14 +99,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt install libgdal-dev
         ## TODO: Install GDAL on Windows and macos
-      - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
-        if: matrix.os == 'windows-latest'
-      - name: Set environment variables on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "CMAKE_GENERATOR=Ninja" >> "$env:GITHUB_ENV" &&
-          echo "CMAKE_CONFIGURATION_TYPES=Release" >> "$env:GITHUB_ENV"
       - name: Restore snapshot data cache
         id: restore-cache-snapshots-release
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
@@ -148,11 +140,11 @@ jobs:
           name: ${{matrix.os}}_${{matrix.c_compiler}}_cmake_profiles
           path: ${{matrix.os}}_${{matrix.c_compiler}}_config_profile.json
       - name: Build library with Makefile
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-2025-vs2026' }}
         working-directory: ${{github.workspace}}/src
         run: make
       - name: Check that library has no compiled asserts
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-2025-vs2026' }}
         working-directory: ${{github.workspace}}/src
         run: |
           if nm libtopotoolbox.a | grep "assert"; then false; else true; fi

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build
         run: cmake --build ${{github.workspace}}/build --target docs
       - name: Package artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ${{github.workspace}}/build/docs/docs/sphinx
   deploy:
@@ -39,4 +39,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Closes #219

Starting from VS 2026, we don't seem to need to set up the developer
command prompt. The windows-latest images will change fully to VS 2026
some time in June 2026, but for now, we can compile on
windows-2025-vs2026.