### PR TITLE
Move graphflood/define_types.h into topotoolbox.h

### DIFF
--- a/include/graphflood/define_types.h
+++ b/include/graphflood/define_types.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#define GF_UINT size_t
-#define GF_INT ptrdiff_t
-#define GF_FLOAT double

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -2022,7 +2022,9 @@ TOPOTOOLBOX_API void propagatevaluesupstream_i64(int64_t *data,
   Graphflood
 */
 
-#include "graphflood/define_types.h"
+#define GF_UINT size_t
+#define GF_INT ptrdiff_t
+#define GF_FLOAT double
 
 /**
    @brief Computes a single flow graph:

--- a/src/graphflood/gf_flowacc.c
+++ b/src/graphflood/gf_flowacc.c
@@ -10,7 +10,6 @@ This file contains routine to accumulate flow downstream, a way or another
 #include <stdint.h>
 
 #include "gf_utils.h"
-#include "graphflood/define_types.h"
 #include "topotoolbox.h"
 
 /*

--- a/src/graphflood/gf_utils.h
+++ b/src/graphflood/gf_utils.h
@@ -8,8 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "graphflood/define_types.h"
-// #include "topotoolbox.h"
+#include "topotoolbox.h"
 
 /*
 Offset helpers:

--- a/src/graphflood/graphflood.c
+++ b/src/graphflood/graphflood.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 
 #include "gf_utils.h"
-#include "graphflood/define_types.h"
 #include "pq_maxheap.h"
 #include "topotoolbox.h"
 

--- a/src/graphflood/pq_maxheap.h
+++ b/src/graphflood/pq_maxheap.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "graphflood/define_types.h"
+#include "topotoolbox.h"
 
 // Define the element structure in the max-heap priority queue
 typedef struct {

--- a/src/graphflood/pq_priority_flood.h
+++ b/src/graphflood/pq_priority_flood.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "graphflood/define_types.h"
+#include "topotoolbox.h"
 
 // Define the element structure in the priority queue
 typedef struct {

--- a/src/graphflood/priority_flood_standalone.c
+++ b/src/graphflood/priority_flood_standalone.c
@@ -14,7 +14,6 @@ A Single flow graph is a data structure describing a Directed Acyclic Graph
 #include <stdio.h>
 
 #include "gf_utils.h"
-#include "graphflood/define_types.h"
 #include "pq_priority_flood.h"
 #include "queue_pit.h"
 #include "topotoolbox.h"

--- a/src/graphflood/queue_pit.h
+++ b/src/graphflood/queue_pit.h
@@ -13,7 +13,7 @@ B.G.
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "graphflood/define_types.h"
+#include "topotoolbox.h"
 
 // Define the queue structure
 typedef struct {

--- a/src/graphflood/sfgraph.c
+++ b/src/graphflood/sfgraph.c
@@ -14,7 +14,6 @@ A Single flow graph is a data structure describing a Directed Acyclic Graph
 #include <stdio.h>
 
 #include "gf_utils.h"
-#include "graphflood/define_types.h"
 #include "pq_priority_flood.h"
 #include "queue_pit.h"
 #include "topotoolbox.h"


### PR DESCRIPTION
Having multiple external header files makes it a little tricker to
install libtopotoolbox. The graphflood/define_types.h header only
defines a few macros, so it is easy enough to include in the main
topotoolbox.h file.

All of the references to graphflood/define_types.h are replaced with
topotoolbox.h in the graphflood source.

@bgailleton: is this all right?