### PR TITLE
Add MFD implementation

### DIFF
--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -3473,9 +3473,21 @@ void flow_routing_mfd_directions(uint8_t *direction, float *totalgradient,
    @endparblock
 
 
+   @param[in] dem The input DEM
+   @parblock
+
+   A float array with size dims[0] x dims[1].
+
+   @endparblock
+
    @param[in]  dims The dimensions of the DEM
    @parblock
    A pair of ptrdiff_t, fastest changing dimension first.
+   @endparblock
+
+   @param[in] order The memory order of the underlying arrays
+   @parblock
+   0 for column-major, 1 for row-major
    @endparblock
  */
 TOPOTOOLBOX_API

--- a/include/topotoolbox.h
+++ b/include/topotoolbox.h
@@ -3391,4 +3391,96 @@ void resolve_flats_lcat(uint8_t *direction, uint8_t *resolved, float *aux,
 TOPOTOOLBOX_API
 void resolve_flats_lcat_weights(float *weight, ptrdiff_t count);
 
+/**
+   @brief Compute multiple flow directions
+
+   @details MFD distributes flow to all downstream neighbors with
+   weights proportional to the gradient.
+
+   @param[out] direction A bitmap edge set
+   @parblock
+
+   A uint8_t array of the same size as the DEM. Each of the 8 bits of
+   each pixel corresponds to an outgoing edge.
+
+   @endparblock
+
+   @param[out] totalgradient Sum of downslope gradients
+   @parblock
+
+   A float array of the same size as the DEM. This is the sum of the
+   gradients from each pixel to its downslope neighbors. This is not
+   particularly useful, but it is needed to normalize the weights and it
+   is easy to compute during the first pass.
+
+   @endparblock
+
+   @param[in] dem The input DEM
+   @parblock
+
+   A float array with size dims[0] x dims[1].
+
+   @endparblock
+
+   @param[in]  dims The dimensions of the DEM
+   @parblock
+   A pair of ptrdiff_t, fastest changing dimension first.
+   @endparblock
+
+   @param[in] order The memory order of the underlying arrays
+   @parblock
+   0 for column-major, 1 for row-major
+   @endparblock
+ */
+TOPOTOOLBOX_API
+void flow_routing_mfd_directions(uint8_t *direction, float *totalgradient,
+                                 float *dem, ptrdiff_t dims[2], int order);
+
+/**
+   @brief Compute and store the MFD edge weights
+
+   @details Once the flow directions and flow proportions have been
+   computed, the edge weights need to be stored in an array in an
+   order that will be used by functions like flow_routing_tsort.
+
+   @param[out] weight The weight array
+   @parblock
+
+   An array of floats that will be filled with the edge weights. This
+   should be preallocated with a size equal to the number of edges in
+   the direction bitmap. This size can be computed using
+   edgeset_count.
+
+   @endparblock
+
+   @param[in] direction The input direction bitmap
+   @parblock
+
+   An array of uint8_t that should come from the direction argument of
+   flow_routing_dinf_directions. This is a bitmap edge set encoded as
+   described elsewhere.
+
+   @endparblock
+
+   @param[out] totalgradient Sum of downslope gradients
+   @parblock
+
+   A float array of the same size as the DEM. This should come from
+   flow_routing_mfd_directions. It is the sum of the gradients from
+   each pixel to its downslope neighbors. It is temporary and can be
+   discarded after the weights are computed.
+
+   @endparblock
+
+
+   @param[in]  dims The dimensions of the DEM
+   @parblock
+   A pair of ptrdiff_t, fastest changing dimension first.
+   @endparblock
+ */
+TOPOTOOLBOX_API
+void flow_routing_mfd_weights(float *weight, float *totalgradient,
+                              uint8_t *direction, float *dem, ptrdiff_t dims[2],
+                              int order);
+
 #endif  // TOPOTOOLBOX_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(topotoolbox
   dinf.c
   d8.c
   lcat.c
+  mfd.c
 )
 
 # Define the include directory

--- a/src/mfd.c
+++ b/src/mfd.c
@@ -1,0 +1,64 @@
+#define TOPOTOOLBOX_BUILD
+
+#include <assert.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "topotoolbox.h"
+
+#define SQRT2 1.41421356237309504880f
+
+TOPOTOOLBOX_API
+void flow_routing_mfd_directions(uint8_t *direction, float *totalgradient,
+                                 float *dem, ptrdiff_t dims[2], int order) {
+  ptrdiff_t e[2][8] = {{0, -1, -1, -1, 0, 1, 1, 1},
+                       {1, 1, 0, -1, -1, -1, 0, 1}};
+
+  float d[8] = {1.0, SQRT2, 1.0, SQRT2, 1.0, SQRT2, 1.0, SQRT2};
+
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      float z = dem[j * dims[0] + i];
+      for (int n = 0; n < 8; n++) {
+        ptrdiff_t i1 = i + e[order & 1][n];
+        ptrdiff_t j1 = j + e[(order ^ 1) & 1][n];
+
+        if (i1 < 0 || i1 >= dims[0] || j1 < 0 || j1 >= dims[1]) continue;
+
+        float z2 = dem[j1 * dims[0] + i1];
+        direction[j * dims[0] + i] |= (z > z2) << n;
+        totalgradient[j * dims[0] + i] += fmaxf(0.0, z - z2) / d[n];
+      }
+    }
+  }
+}
+
+TOPOTOOLBOX_API
+void flow_routing_mfd_weights(float *weight, float *totalgradient,
+                              uint8_t *direction, float *dem, ptrdiff_t dims[2],
+                              int order) {
+  ptrdiff_t e[2][8] = {{0, -1, -1, -1, 0, 1, 1, 1},
+                       {1, 1, 0, -1, -1, -1, 0, 1}};
+
+  float d[8] = {1.0, SQRT2, 1.0, SQRT2, 1.0, SQRT2, 1.0, SQRT2};
+
+  ptrdiff_t edge = 0;
+  for (ptrdiff_t j = 0; j < dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < dims[0]; i++) {
+      ptrdiff_t idx = j * dims[0] + i;
+      float z = dem[idx];
+      float g = totalgradient[idx];
+
+      for (int n = 0; n < 8; n++) {
+        if (direction[idx] & (1 << n)) {
+          ptrdiff_t i1 = i + e[order & 1][n];
+          ptrdiff_t j1 = j + e[(order ^ 1) & 1][n];
+          float z2 = dem[j1 * dims[0] + i1];
+
+          weight[edge++] = ((z - z2) / d[n]) / g;
+        }
+      }
+    }
+  }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,6 +176,18 @@ if(GDAL_FOUND AND TT_SNAPSHOT_DIR)
   add_test(NAME d8 COMMAND d8 ${TT_SNAPSHOT_DIR})
   set_tests_properties(d8 PROPERTIES ENVIRONMENT_MODIFICATION
     "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
+
+  # TEST : mfd
+  #
+  add_executable(mfd mfd.c utils.c grid.c flow.c)
+  if(TT_SANITIZE AND NOT MSVC)
+    target_compile_options(mfd PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
+    target_link_options(mfd PRIVATE "$<$<CONFIG:DEBUG>:-fsanitize=address>")
+  endif()
+  target_link_libraries(mfd PRIVATE topotoolbox GDAL::GDAL)
+  add_test(NAME mfd COMMAND mfd ${TT_SNAPSHOT_DIR})
+  set_tests_properties(mfd PROPERTIES ENVIRONMENT_MODIFICATION
+    "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:topotoolbox>>")
 endif()
 
 		   

--- a/test/mfd.c
+++ b/test/mfd.c
@@ -1,0 +1,722 @@
+#undef NDEBUG
+
+#include <assert.h>
+#include <gdal.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "flow.h"
+#include "grid.h"
+#include "topotoolbox.h"
+#include "utils.h"
+
+#define test(desc)                                               \
+  for (int _res = 0, _break = 1; _break; _break = 0,             \
+           _res ? printf("not ok %d - %s\n", ++_testcount, desc) \
+                : printf("ok %d - %s\n", ++_testcount, desc),    \
+           _success |= _res)
+#define test_fail _res = 1
+#define test_init()                                                    \
+  for (int _success = 0, _testcount = (printf("TAP version 14\n"), 0), \
+           _break = 1;                                                 \
+       _break; _break = 0, printf("1..%d\n", _testcount), exit(_success))
+
+ptrdiff_t ei[8] = {0, -1, -1, -1, 0, 1, 1, 1};
+ptrdiff_t ej[8] = {1, 1, 0, -1, -1, -1, 0, 1};
+
+void print_flow(Flow f) {
+  printf("%ld edges\n", f.count);
+  for (ptrdiff_t e = 0; e < f.count; e++) {
+    printf("%ld %ld %f\n", f.source[e], f.target[e], f.fraction[e]);
+  }
+}
+
+int test_node_once(Flow f) {
+  // Has every node been assigned exactly once?
+  Grid count = GridCreate(GridF32, NULL, f.cellsize, f.dims);
+  for (ptrdiff_t j = 0; j < f.dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < f.dims[0]; i++) {
+      ((float *)count.data)[f.stream[j * f.dims[0] + i]] += 1.0;
+    }
+  }
+
+  Grid ones = GridFill(1.0, count.cellsize, count.dims);
+
+  int res = GridEq(count, ones);
+
+  GridFree(&count);
+  GridFree(&ones);
+
+  return res;
+}
+
+int test_tsort_node(Flow fd) {
+  // Is the node list topologically sorted?
+  // For every edge u => v, u comes before v in the node list
+
+  int res = 0;
+
+  // idxs maps every cell to its position in the node list
+  Grid idxs = GridCreate(GridIdx, NULL, fd.cellsize, fd.dims);
+  for (ptrdiff_t j = 0; j < fd.dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < fd.dims[0]; i++) {
+      ((ptrdiff_t *)idxs.data)[fd.stream[j * fd.dims[0] + i]] =
+          j * fd.dims[0] + i;
+    }
+  }
+
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+    ptrdiff_t v = fd.target[e];
+
+    res = ((ptrdiff_t *)idxs.data)[u] < ((ptrdiff_t *)idxs.data)[v] ? 1 : 0;
+  }
+
+  GridFree(&idxs);
+  return res;
+}
+
+int test_tsort(Flow fd) {
+  // Are the edge lists topologically sorted?
+  // All incoming edges to a vertex v occur before any outgoing edges
+
+  int tsort_success = 1;
+
+  Grid outdegree = GridCreate(GridU8, NULL, fd.cellsize, fd.dims);
+
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+    ptrdiff_t v = fd.target[e];
+
+    ((uint8_t *)outdegree.data)[u] += 1;
+    if (((uint8_t *)outdegree.data)[v] > 0) {
+      tsort_success = 0;
+    }
+  }
+  if (!tsort_success) {
+    printf("# Edge list was not topologically sorted\n");
+  }
+  GridFree(&outdegree);
+  return tsort_success;
+}
+
+int test_nanflow(Flow fd, Grid dem) {
+  // Missing data in the DEM should have no flow into or out of them.
+  int res = 1;
+
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+    ptrdiff_t v = fd.target[e];
+    if (isnan(((float *)dem.data)[u])) {
+      res = 0;
+      printf("# NaN pixel of DEM is a source: %ld\n", u);
+    }
+
+    if (isnan(((float *)dem.data)[v])) {
+      res = 0;
+      printf("# NaN pixel of DEM is a target: %ld\n", v);
+    }
+  }
+
+  return res;
+}
+
+int test_no_boundary_edges(Flow fd) {
+  // No edges should originate from outside the domain or leave the
+  // domain
+  int res = 1;
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+    ptrdiff_t v = fd.target[e];
+
+    ptrdiff_t ui = u % fd.dims[0];
+    ptrdiff_t uj = u / fd.dims[0];
+
+    ptrdiff_t vi = v % fd.dims[0];
+    ptrdiff_t vj = v / fd.dims[0];
+
+    if (llabs(ui - vi) > 1 || llabs(uj - vj) > 1) {
+      printf("# Indices (%ld, %ld) and (%ld,%ld) are not neighbors.\n", ui, uj,
+             vi, vj);
+    }
+
+    if (ui < 0 || ui >= fd.dims[0] || uj < 0 || uj >= fd.dims[1]) {
+      printf("# Edge %ld => %ld originates from outside the domain.\n", u, v);
+      res = 0;
+    }
+
+    if (vi < 0 || vi >= fd.dims[0] || vj < 0 || vj >= fd.dims[1]) {
+      printf("# Edge %ld => %ld leaves the domain.\n", u, v);
+      res = 0;
+    }
+  }
+  return res;
+}
+
+int test_outlets(Flow fd) {
+  // There should be at least one outlet, a pixel with incoming edges
+  // but no outgoing edges.
+  Grid outdegree = GridCreate(GridU8, NULL, fd.cellsize, fd.dims);
+  Grid indegree = GridCreate(GridU8, NULL, fd.cellsize, fd.dims);
+
+  uint8_t *outdegree_data = outdegree.data;
+  uint8_t *indegree_data = indegree.data;
+
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+    ptrdiff_t v = fd.target[e];
+
+    outdegree_data[u] += 1;
+    indegree_data[v] += 1;
+  }
+
+  int res = 0;
+  for (ptrdiff_t j = 0; j < fd.dims[1]; j++) {
+    for (ptrdiff_t i = 0; i < fd.dims[0]; i++) {
+      if (indegree_data[j * fd.dims[0] + i] > 0 &&
+          outdegree_data[j * fd.dims[0] + i] == 0) {
+        // This is an outlet
+        res = 1;
+      }
+    }
+  }
+
+  GridFree(&outdegree);
+  GridFree(&indegree);
+
+  return res;
+}
+
+int test_sum_edge_weights(Flow fd) {
+  // Outgoing edge weights should sum to one
+  int res = 1;
+
+  Grid edge_sums = GridCreate(GridF32, NULL, fd.cellsize, fd.dims);
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+
+    ((float *)edge_sums.data)[u] += fd.fraction[e];
+  }
+
+  for (ptrdiff_t e = 0; e < fd.count; e++) {
+    ptrdiff_t u = fd.source[e];
+
+    float s = ((float *)edge_sums.data)[u];
+    if (fabsf(s - 1) > 1e-3) {
+      printf("# Outgoing edges from pixel %ld sum to %f rather than 1.\n", u,
+             s);
+      res = 0;
+    }
+  }
+  GridFree(&edge_sums);
+
+  return res;
+}
+
+Flow mfd_flow(Grid dem, int order) {
+  Flow fd = {0};
+
+  Grid direction = GridCreate(GridU8, NULL, dem.cellsize, dem.dims);
+  Grid totalgradient = GridCreate(GridF32, NULL, dem.cellsize, dem.dims);
+
+  flow_routing_mfd_directions(direction.data, totalgradient.data, dem.data,
+                              dem.dims, order);
+
+  ptrdiff_t edge_count = edgeset_count(direction.data, dem.dims);
+
+  float *weight = calloc(edge_count, sizeof *weight);
+
+  flow_routing_mfd_weights(weight, totalgradient.data, direction.data, dem.data,
+                           direction.dims, order);
+
+  Grid weightscan = GridCreate(GridIdx, NULL, dem.cellsize, dem.dims);
+  ptrdiff_t edge_count2 =
+      edgeset_scan(weightscan.data, direction.data, direction.dims);
+
+  if (edge_count != edge_count2) {
+    printf("# Edge count from scan not equal: %ld != %ld", edge_count,
+           edge_count2);
+  }
+
+  // Compute the topological sort of the merged edge set.
+  Grid stream = GridCreate(GridIdx, NULL, dem.cellsize, dem.dims);
+  ptrdiff_t *source = calloc(edge_count, sizeof *source);
+  ptrdiff_t *target = calloc(edge_count, sizeof *target);
+  float *sorted_weight = calloc(edge_count, sizeof *sorted_weight);
+
+  Grid stack = GridCreate(GridIdx, NULL, dem.cellsize, dem.dims);
+  Grid stackdir = GridCreate(GridU8, NULL, dem.cellsize, dem.dims);
+  Grid visited = GridCreate(GridU8, NULL, dem.cellsize, dem.dims);
+
+  flow_routing_tsort(stream.data, source, target, sorted_weight, stack.data,
+                     stackdir.data, direction.data, weight, weightscan.data,
+                     visited.data, edge_count, dem.dims, order);
+
+  fd.count = edge_count;
+  fd.stream = stream.data;
+  fd.source = source;
+  fd.target = target;
+  fd.fraction = sorted_weight;
+  fd.cellsize = dem.cellsize;
+  fd.dims[0] = dem.dims[0];
+  fd.dims[1] = dem.dims[1];
+
+  GridFree(&stack);
+  GridFree(&stackdir);
+  GridFree(&visited);
+  GridFree(&weightscan);
+  GridFree(&direction);
+  GridFree(&totalgradient);
+
+  free(weight);
+
+  return fd;
+}
+
+int main(int argc, char *argv[]) {
+  GDALAllRegister();
+
+  const char *snapshot_directory = "";
+
+  if (argc >= 2) {
+    snapshot_directory = argv[1];
+  }
+
+  test_init() {
+    test("Slope") {
+      ptrdiff_t dims[2] = {3, 3};
+      float data[9] = {2, 2, 2, 1, 1, 1, 0, 0, 0};
+      Grid dem = GridCreate(GridF32, data, 1.0, dims);
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+    }
+
+    test("Larger slope") {
+      ptrdiff_t dims[2] = {5, 5};
+      float data[25] = {4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 2, 2, 2,
+                        2, 2, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0};
+      Grid dem = GridCreate(GridF32, data, 1.0, dims);
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+    }
+
+    test("Diagonal") {
+      ptrdiff_t dims[2] = {3, 3};
+      float data[9] = {2, 3, 4, 1, 2, 3, 0, 1, 2};
+      Grid dem = GridCreate(GridF32, data, 1.0, dims);
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+    }
+
+    test("Sink") {
+      ptrdiff_t dims[2] = {5, 5};
+      float data[25] = {0, 0, 0, 0, 0, 0, 2, 2, 2, 0, 0, 2, 1,
+                        2, 0, 0, 2, 2, 2, 0, 0, 0, 0, 0, 0};
+      Grid dem = GridCreate(GridF32, data, 1.0, dims);
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+    }
+
+    test("Outward sloping cone") {
+      ptrdiff_t dims[2] = {16, 16};
+      float cellsize = 150.0 / (dims[0] - 1);
+      Grid dem = GridCreate(GridF32, NULL, cellsize, dims);
+      for (ptrdiff_t j = 0; j < dims[1]; j++) {
+        for (ptrdiff_t i = 0; i < dims[0]; i++) {
+          float x = cellsize * i - 75.0;
+          float y = cellsize * j - 75.0;
+          ((float *)dem.data)[j * dims[0] + i] = 200 - sqrtf(x * x + y * y);
+        }
+      }
+
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+      GridFree(&dem);
+    }
+
+    test("Outward sloping cone with flats") {
+      ptrdiff_t dims[2] = {16, 16};
+      float cellsize = 150.0 / (dims[0] - 1);
+      Grid dem = GridCreate(GridF32, NULL, cellsize, dims);
+      for (ptrdiff_t j = 0; j < dims[1]; j++) {
+        for (ptrdiff_t i = 0; i < dims[0]; i++) {
+          float x = cellsize * i - 75.0;
+          float y = cellsize * j - 75.0;
+          ((float *)dem.data)[j * dims[0] + i] =
+              fminf(150.0, 200 - sqrtf(x * x + y * y));
+        }
+      }
+
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+      GridFree(&dem);
+    }
+
+    if (*snapshot_directory) {
+      test("bigtujunga") {
+        const char *filepath = "/bigtujunga_30m/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+
+      test("perfectworld") {
+        const char *filepath = "/perfectworld/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+
+      test("tibet") {
+        const char *filepath = "/tibet/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+
+      test("kedarnath") {
+        const char *filepath = "/kedarnath/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+
+      test("kunashiri") {
+        const char *filepath = "/kunashiri/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+
+      test("taiwan") {
+        const char *filepath = "/taiwan/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+
+      test("taalvolcano") {
+        const char *filepath = "/taalvolcano/dem.tif";
+        char *path = calloc(strlen(snapshot_directory) + strlen(filepath) + 1,
+                            sizeof *path);
+        strcpy(path, snapshot_directory);
+        strncat(path, filepath, strlen(filepath) + 1);
+        printf("# %s\n", path);
+
+        Grid dem = GridFromFile(path);
+        free(path);
+
+        Grid demf = GridFillsinks(dem);
+        Flow fd = mfd_flow(demf, 0);
+
+        if (!test_node_once(fd)) test_fail;
+        if (!test_tsort_node(fd)) test_fail;
+        if (!test_tsort(fd)) test_fail;
+        if (!test_nanflow(fd, dem)) test_fail;
+        if (!test_no_boundary_edges(fd)) test_fail;
+        if (!test_outlets(fd)) test_fail;
+        if (!test_sum_edge_weights(fd)) test_fail;
+
+        FlowFree(&fd);
+        GridFree(&demf);
+        GridFree(&dem);
+      }
+    }
+
+    test("nans") {
+      ptrdiff_t dims[2] = {5, 5};
+      ptrdiff_t cellsize = 1.0;
+      Grid dem = GridCreate(GridF32, NULL, cellsize, dims);
+
+      for (ptrdiff_t j = 0; j < dims[1]; j++) {
+        for (ptrdiff_t i = 0; i < dims[0]; i++) {
+          float x = cellsize * i;
+          float y = cellsize * j;
+          ((float *)dem.data)[j * dims[0] + i] = x + y;
+        }
+      }
+      ((float *)dem.data)[2 * dims[0] + 2] = NAN;
+
+      Flow fd = mfd_flow(dem, 0);
+
+      if (!test_node_once(fd)) test_fail;
+      if (!test_tsort_node(fd)) test_fail;
+      if (!test_tsort(fd)) test_fail;
+      if (!test_nanflow(fd, dem)) test_fail;
+      if (!test_no_boundary_edges(fd)) test_fail;
+      if (!test_outlets(fd)) test_fail;
+      if (!test_sum_edge_weights(fd)) test_fail;
+
+      FlowFree(&fd);
+      GridFree(&dem);
+    }
+
+    test("Memory order slope") {
+      ptrdiff_t dims[2] = {5, 7};
+
+      Grid fdem = GridCreate(GridF32, NULL, 1.0, dims);
+      for (ptrdiff_t j = 0; j < dims[1]; j++) {
+        for (ptrdiff_t i = 0; i < dims[0]; i++) {
+          float z = j * dims[0] + i;
+          ((float *)fdem.data)[j * dims[0] + i] = z;
+        }
+      }
+
+      Grid cdem = GridTranspose(fdem);
+
+      Grid fdemf = GridFillsinks(fdem);
+      GridFree(&fdem);
+
+      Grid cdemf = GridFillsinks(cdem);
+      GridFree(&cdem);
+
+      Flow cfd = mfd_flow(cdemf, 1);
+      Flow ffd = mfd_flow(fdemf, 0);
+
+      Grid cacc = FlowAccumulation(cfd);
+      Grid facc = FlowAccumulation(ffd);
+      Grid caccT = GridTranspose(cacc);
+
+      if (!GridAllClose(caccT, facc, 1e-5)) test_fail;
+
+      GridFree(&caccT);
+      GridFree(&cacc);
+      GridFree(&facc);
+      GridFree(&fdemf);
+      GridFree(&cdemf);
+
+      FlowFree(&ffd);
+      FlowFree(&cfd);
+    }
+
+    test("Memory order saddle (ties)") {
+      ptrdiff_t dims[2] = {3, 3};
+      ptrdiff_t fdims[2] = {dims[0], dims[1]};
+
+      float fdem_buffer[9] = {2, 2, 0, 2, 1, 2, 0, 2, 2};
+
+      Grid fdem = GridCreate(GridF32, fdem_buffer, 1.0, fdims);
+      Grid cdem = GridTranspose(fdem);
+
+      Flow cfd = mfd_flow(cdem, 1);
+      Flow ffd = mfd_flow(fdem, 0);
+
+      Grid cacc = FlowAccumulation(cfd);
+      Grid facc = FlowAccumulation(ffd);
+      Grid caccT = GridTranspose(cacc);
+
+      if (!GridAllClose(caccT, facc, 1e-5)) test_fail;
+
+      GridFree(&caccT);
+      GridFree(&cacc);
+      GridFree(&facc);
+      GridFree(&cdem);
+
+      FlowFree(&ffd);
+      FlowFree(&cfd);
+    }
+
+    test("Memory order random") {
+      ptrdiff_t dims[2] = {32, 31};
+
+      Grid fdem = GridRandom(0x746f706f7f6f6f6c, 1.0, dims);
+
+      Grid cdem = GridTranspose(fdem);
+
+      Grid fdemf = GridFillsinks(fdem);
+      GridFree(&fdem);
+      Grid cdemf = GridFillsinks(cdem);
+      GridFree(&cdem);
+
+      Flow cfd = mfd_flow(cdemf, 1);
+      Flow ffd = mfd_flow(fdemf, 0);
+
+      Grid cacc = FlowAccumulation(cfd);
+      Grid facc = FlowAccumulation(ffd);
+
+      Grid caccT = GridTranspose(cacc);
+
+      if (!GridAllClose(caccT, facc, 1e-5)) test_fail;
+
+      GridFree(&caccT);
+      GridFree(&cacc);
+      GridFree(&facc);
+
+      FlowFree(&ffd);
+      FlowFree(&cfd);
+
+      GridFree(&fdemf);
+      GridFree(&cdemf);
+    }
+  }
+}


### PR DESCRIPTION
Resolves #236

A new file, src/mfd.c, contains the two flow routing interface functions for multiple flow direction routing. These are

- flow_routing_mfd_directions
- flow_routing_mfd_weights

As in Dinf, the former computes a bitset of directions and also sums the gradients along the way to normalize the weights later. Once we know how many edges we have, we can allocate and compute the weights with flow_routing_mfd_weights.

These tests are copied from the Dinf tests, with appropriate modifications to the flow routing subroutine.

The only difference in the tests is that the sum of edge weights is permitted to be numerically different from 1.0. Some of the test case sizes were also changed for debugging purposes and have been left as they were.

I may hold off on merging this for a little bit because I have not successfully implemented the MATLAB MFD flat resolution algorithm yet, and I want to make sure that we have all the information we need for that.